### PR TITLE
Add missing opgroups to none policy

### DIFF
--- a/osv/none.dpl
+++ b/osv/none.dpl
@@ -50,7 +50,9 @@ policy:
             ^ csrGrp(code == _, env == _, op1 == _, csr == _ -> env = env, csr = {}, res = {})
             ^ csriGrp(code == _, env == _, csr == _ -> env = env, csr = {}, res = {})
             ^ privGrp(code == _, env == _ -> env = env)
-//            ^ systemGrp(code == _, env == _ -> env = env)
+            ^ systemGrp(code == _, env == _ -> env = env)
+            ^ floatGrp(code == _, env == _ -> env = env)
+            ^ atomicGrp(code == _, env == _ -> env = env)
 
 require:
     init ISA.RISCV.Reg.Env                   {Nothing}

--- a/osv/riscv.dpl
+++ b/osv/riscv.dpl
@@ -215,19 +215,13 @@ group:
         uret
         sret
         mret
-// TODO: finish up defining these groups and update to 1.10
-/*
-        sbreak
-        sfence.vm
+        sfence.vma
         wfi
-        mrth
-        mrts
-        hrts
-    systemGrp()
+
+    systemGrp( -> )
         fence
         fence.i
 
-*/
 
     floatGrp( -> )
         flw
@@ -424,15 +418,11 @@ group:
         uret
         sret
         mret
-        sret
-        // sfence.vm
+        sfence.vma
         wfi
-        // mrth
-        // mrts
-        // hrts
     // systemGrp()
         fence
-        // fence.i
+        fence.i
 
 
     notMemGrp( -> )
@@ -506,15 +496,11 @@ group:
         uret
         sret
         mret
-        sret
-        // sfence.vm
+        sfence.vma
         wfi
-        // mrth
-        // mrts
-        // hrts
     // systemGrp()
         fence
-        // fence.i
+        fence.i
 //floatGrp( -> )
         flw
 	fld


### PR DESCRIPTION
- Fix opgroups for priv spec 1.10 instructions
- Add atomics, floats, priv groups to none policy