### PR TITLE
This adds a policy that performs absolutely no checks.

### DIFF
--- a/osv/frtos/main.dpl
+++ b/osv/frtos/main.dpl
@@ -26,8 +26,11 @@
 
 module osv.frtos.main:
 
-/* Composition of four micro-policies.
- * All four policies are evaluated in parallel
+/* All interesting compositions of our current micropolicies.
+ *
+ * TODO: It is worth considering whether we should eliminate the need for
+ * this file by allowing the policy tool to accept multiple policies at the
+ * command line.
  */
 
 import:
@@ -35,62 +38,54 @@ import:
     osv.rwx
     osv.stack
     osv.heap
-    osv.nop
-    osv.none
     osv.threeClass
+    osv.none
+    osv.testSimple
+    osv.testComplex
     
 policy:
     none = nonePol
+    testSimple = testSimplePol
+    testComplex = testComplexPol
+
     cfi =  cfiPol
-    rwx =  rwxPol
-    nop =  nopPol
     heap = heapPol
+    rwx =  rwxPol
     stack = stackPol
     threeClass = threeClassPol
 
-    nop-threeClass =  threeClassPol & nopPol
-    rwx-threeClass =  (threeClassPol & rwxPol)
-    stack-threeClass =  threeClassPol & stackPol
-    
     cfi-heap = cfiPol & heapPol
-    cfi-nop =  cfiPol & nopPol
-    cfi-rwx =  (cfiPol & rwxPol)
-    cfi-stack =  cfiPol & stackPol
+    cfi-rwx = cfiPol & rwxPol
+    cfi-stack = cfiPol & stackPol
+    cfi-threeClass = cfiPol & threeClassPol
 
-    heap-nop = heapPol & nopPol
     heap-rwx = heapPol & rwxPol
     heap-stack = heapPol & stackPol
-
-    nop-rwx =  nopPol & rwxPol  
-    nop-stack =  nopPol & stackPol
+    heap-threeClass = heapPol & threeClassPol
 
     rwx-stack =  rwxPol & stackPol
+    rwx-threeClass = threeClassPol & rwxPol
 
-    cfi-heap-nop = cfiPol & heapPol & nopPol
+    stack-threeClass =  threeClassPol & stackPol
+
     cfi-heap-rwx = cfiPol & heapPol & rwxPol
     cfi-heap-stack = cfiPol & heapPol & stackPol
-    cfi-nop-rwx =  cfiPol & nopPol & rwxPol
-    cfi-nop-stack =  cfiPol & nopPol & stackPol
+    cfi-heap-threeClass = cfiPol & heapPol & threeClassPol
     cfi-rwx-stack =  cfiPol & rwxPol & stackPol
+    cfi-rwx-threeClass =  cfiPol & rwxPol & threeClassPol
+    cfi-stack-threeClass = cfiPol & stackPol & threeClassPol
 
-    heap-nop-rwx = heapPol & nopPol & rwxPol
-    heap-nop-stack = heapPol & nopPol & stackPol
     heap-rwx-stack = heapPol & rwxPol & stackPol
+    heap-rwx-threeClass = heapPol & rwxPol & threeClassPol
+    heap-stack-threeclass = heapPol & stackPol & threeClassPol
 
-    nop-rwx-stack =  nopPol & rwxPol & stackPol
-
-    nop-rwx-threeClass =  threeClassPol & nopPol & rwxPol
-    nop-stack-threeClass =  threeClassPol & nopPol & stackPol
     rwx-stack-threeClass =  threeClassPol & rwxPol & stackPol
 
-    nop-rwx-stack-threeClass =  threeClassPol & nopPol & rwxPol & stackPol
-    cfi-heap-nop-rwx = cfiPol & heapPol & nopPol & rwxPol
-    cfi-heap-nop-stack = cfiPol & heapPol & nopPol & stackPol
     cfi-heap-rwx-stack = cfiPol & heapPol & rwxPol & stackPol
-    cfi-nop-rwx-stack =  cfiPol & nopPol & rwxPol & stackPol
-    heap-nop-rwx-stack = heapPol & nopPol & rwxPol & stackPol
+    cfi-heap-rwx-threeClass = cfiPol & heapPol & rwxPol & threeClassPol
+    cfi-heap-stack-threeClass = cfiPol & heapPol & stackPol & threeClassPol
+    cfi-rwx-stack-threeClass = cfiPol & rwxPol & stackPol & threeClassPol
 
-    cfi-heap-nop-rwx-stack = cfiPol & heapPol & nopPol & rwxPol & stackPol
+    heap-rwx-stack-threeClass = heapPol & rwxPol & stackPol & threeClassPol
 
-
-
+    cfi-heap-rwx-stack-threeClass = cfiPol & heapPol & rwxPol & stackPol & threeClassPol

--- a/osv/hifive/main.dpl
+++ b/osv/hifive/main.dpl
@@ -26,72 +26,104 @@
 
 module osv.hifive.main:
 
-/* Composition of four micro-policies.
- * All four policies are evaluated in parallel
+/* All interesting compositions of our current micropolicies.
+ *
+ * TODO: It is worth considering whether we should eliminate the need for
+ * this file by allowing the policy tool to accept multiple policies at the
+ * command line.
  */
 
 import:
     osv.cfi
     osv.rwx
     osv.stack
-    osv.nop
-    osv.none
     osv.heap
     osv.threeClass
     osv.cpi
+    osv.none
+    osv.testSimple
+    osv.testComplex
 
 policy:
     none = nonePol
+    testSimple = testSimplePol
+    testComplex = testComplexPol
+
     cfi =  cfiPol
-    rwx =  rwxPol
-    nop =  nopPol
-    stack = stackPol
-    threeClass = threeClassPol
     cpi = cpiPol
     heap = heapPol
+    rwx =  rwxPol
+    stack = stackPol
+    threeClass = threeClassPol
 
-    nop-threeClass =  threeClassPol & nopPol
-    rwx-threeClass =  (threeClassPol & rwxPol)
-    stack-threeClass =  threeClassPol & stackPol
+    cfi-cpi = cfiPol & cpiPol
+    cfi-heap = cfiPol & heapPol
+    cfi-rwx = cfiPol & rwxPol
+    cfi-stack = cfiPol & stackPol
+    cfi-threeClass = cfiPol & threeClassPol
 
-    cfi-nop =  cfiPol & nopPol
-    cfi-rwx =  (cfiPol & rwxPol)
-    cfi-stack =  cfiPol & stackPol
-
-    cpi-nop =  cpiPol & nopPol
-    cpi-rwx =  (cpiPol & rwxPol)
-    cpi-stack =  cpiPol & stackPol
+    cpi-heap = cpiPol & heapPol
+    cpi-rwx = cpiPol & rwxPol
+    cpi-stack = cpiPol & stackPol
+    cpi-threeClass = cpiPol & threeClassPol
     
-    nop-rwx =  nopPol & rwxPol  
-    nop-stack =  nopPol & stackPol
-
-    rwx-stack =  rwxPol & stackPol
-
     heap-rwx = heapPol & rwxPol
     heap-stack = heapPol & stackPol
-    heap-threeClass = threeClassPol & heapPol
+    heap-threeClass = heapPol & threeClassPol
+
+    rwx-stack =  rwxPol & stackPol
+    rwx-threeClass = threeClassPol & rwxPol
+
+    stack-threeClass =  threeClassPol & stackPol
+
+    cfi-cpi-heap = cfiPol & cpiPol & heapPol
+    cfi-cpi-rwx = cfiPol & cpiPol & rwxPol
+    cfi-cpi-stack = cfiPol & cpiPol & stackPol
+    cfi-cpi-threeClass = cfiPol & cpiPol & threeClassPol
+    cfi-heap-rwx = cfiPol & heapPol & rwxPol
+    cfi-heap-stack = cfiPol & heapPol & stackPol
+    cfi-heap-threeClass = cfiPol & heapPol & threeClassPol
+    cfi-rwx-stack =  cfiPol & rwxPol & stackPol
+    cfi-rwx-threeClass =  cfiPol & rwxPol & threeClassPol
+    cfi-stack-threeClass = cfiPol & stackPol & threeClassPol
+
+    cpi-heap-rwx = cpiPol & heapPol & rwxPol
+    cpi-heap-stack = cpiPol & heapPol & stackPol
+    cpi-heap-threeClass = cpiPol & heapPol & threeClassPol
+    cpi-rwx-stack =  cpiPol & rwxPol & stackPol
+    cpi-rwx-threeClass =  cpiPol & rwxPol & threeClassPol
+    cpi-stack-threeClass = cpiPol & stackPol & threeClassPol
+
     heap-rwx-stack = heapPol & rwxPol & stackPol
     heap-rwx-threeClass = heapPol & rwxPol & threeClassPol
-    heap-stack-threeClass = heapPol & stackPol & threeClassPol
+    heap-stack-threeclass = heapPol & stackPol & threeClassPol
 
-    nop-rwx-threeClass =  threeClassPol & nopPol & rwxPol
-    nop-stack-threeClass =  threeClassPol & nopPol & stackPol
     rwx-stack-threeClass =  threeClassPol & rwxPol & stackPol
 
-    heap-rwx-stack-threeClass = threeClassPol & rwxPol & stackPol & heapPol
+    cfi-cpi-heap-rwx = cfiPol & cpiPol & heapPol & rwxPol
+    cfi-cpi-heap-stack = cfiPol & cpiPol & heapPol & stackPol
+    cfi-cpi-heap-threeClass = cfiPol & cpiPol & heapPol & threeClassPol
+    cfi-cpi-rwx-stack = cfiPol & cpiPol & rwxPol & stackPol
+    cfi-cpi-rwx-threeClass = cfiPol & cpiPol & rwxPol & threeClassPol
+    cfi-cpi-stack-threeClass = cfiPol & cpiPol & stackPol & threeClassPol
+    cfi-heap-rwx-stack = cfiPol & heapPol & rwxPol & stackPol
+    cfi-heap-rwx-threeClass = cfiPol & heapPol & rwxPol & threeClassPol
+    cfi-heap-stack-threeClass = cfiPol & heapPol & stackPol & threeClassPol
+    cfi-rwx-stack-threeClass = cfiPol & rwxPol & stackPol & threeClassPol
 
-    cfi-nop-rwx =  cfiPol & nopPol & rwxPol
-    cfi-nop-stack =  cfiPol & nopPol & stackPol
-    cfi-rwx-stack =  cfiPol & rwxPol & stackPol
-
-    cpi-nop-rwx =  cpiPol & nopPol & rwxPol
-    cpi-nop-stack =  cpiPol & nopPol & stackPol
-    cpi-rwx-stack =  cpiPol & rwxPol & stackPol
-    
-    nop-rwx-stack =  nopPol & rwxPol & stackPol
-
-    nop-rwx-stack-threeClass =  threeClassPol & nopPol & rwxPol & stackPol
-    cfi-nop-rwx-stack =  cfiPol & nopPol & rwxPol & stackPol
-    cpi-nop-rwx-stack =  cfiPol & nopPol & rwxPol & stackPol
-
+    cpi-heap-rwx-stack = cpiPol & heapPol & rwxPol & stackPol
+    cpi-heap-rwx-threeClass = cpiPol & heapPol & rwxPol & threeClassPol
+    cpi-heap-stack-threeClass = cpiPol & heapPol & stackPol & threeClassPol
     cpi-rwx-stack-threeClass = cpiPol & rwxPol & stackPol & threeClassPol
+
+    heap-rwx-stack-threeClass = heapPol & rwxPol & stackPol & threeClassPol
+
+    cfi-cpi-heap-rwx-stack = cfiPol & cpiPol & heapPol & rwxPol & stackPol
+    cfi-cpi-heap-rwx-threeClass = cfiPol & cpiPol & heapPol & rwxPol & threeClassPol
+    cfi-cpi-heap-stack-threeclass = cfiPol & cpiPol & heapPol & stackPol & threeClassPol
+    cfi-cpi-rwx-stack-threeClass = cfiPol & cpiPol & threeClassPol & rwxPol & stackPol
+    cfi-heap-rwx-stack-threeClass = cfiPol & heapPol & rwxPol & stackPol & threeClassPol
+
+    cpi-heap-rwx-stack-threeClass = cpiPol & heapPol & rwxPol & stackPol & threeClassPol
+
+    cfi-cpi-heap-rwx-stack-threeClass = cfiPol & cpiPol & heapPol & rwxPol & stackPol & threeClassPol

--- a/osv/none.dpl
+++ b/osv/none.dpl
@@ -26,51 +26,30 @@
 
 module osv.none:
 
-/* None Policy
- * Provides no security
+/* "none" policy
+ * performs no checks whatsoever
  */
 
-import:
-      osv.riscv
-
-metadata:
-        Nothing
-
 policy:
-        // a policy that allows anything and contributes no results
-    nonePol = branchGrp(code == _, env == _, op1 == _, op2 == _ -> env = env )
-            ^ jumpRegGrp(code == _, env == _, target == _ -> env = env , return = {})
-            ^ jumpGrp(code == _, env == _ -> return = {})
-            ^ loadUpperGrp(code == _, env == _ -> env = env, dest = {})
-            ^ immArithGrp(code == _, env == _, op1 == _ -> env = env, res = {})
-            ^ arithGrp(code == _, env == _, op1 == _, op2 == _ -> env = env, res = {})
-            ^ loadGrp(code == _, env == _, addr == _, mem == _ -> env = env, res = {})
-            ^ storeGrp(code == _, env == _, addr == _, val == _, mem == _ -> env = env, mem = {})
-            ^ mulDivRemGrp(code == _, env == _, op1 == _, op2 == _ -> env = env, res = {})
-            ^ csrGrp(code == _, env == _, op1 == _, csr == _ -> env = env, csr = {}, res = {})
-            ^ csriGrp(code == _, env == _, csr == _ -> env = env, csr = {}, res = {})
-            ^ privGrp(code == _, env == _ -> env = env)
-            ^ systemGrp(code == _, env == _ -> env = env)
-            ^ floatGrp(code == _, env == _ -> env = env)
-            ^ atomicGrp(code == _, env == _ -> env = env)
+    nonePol = __NO_CHECKS
 
 require:
-    init ISA.RISCV.Reg.Env                   {Nothing}
-    init ISA.RISCV.Reg.Default               {Nothing}
-    init ISA.RISCV.Reg.RZero                 {Nothing}
-    init ISA.RISCV.CSR.Default               {Nothing}
-    init ISA.RISCV.CSR.MTVec                 {Nothing}
+   init ISA.RISCV.Reg.Env                   {}
+   init ISA.RISCV.Reg.Default               {}
+   init ISA.RISCV.Reg.RZero                 {}
+   init ISA.RISCV.CSR.Default               {}
+   init ISA.RISCV.CSR.MTVec                 {}
 
-    init Tools.Link.MemoryMap.Default        {Nothing}
-    init Tools.Link.MemoryMap.UserHeap       {Nothing}
-    init Tools.Link.MemoryMap.UserStack      {Nothing}
+   init Tools.Link.MemoryMap.Default        {}
+   init Tools.Link.MemoryMap.UserHeap       {}
+   init Tools.Link.MemoryMap.UserStack      {}
 
-    init SOC.IO.UART_0                       {Nothing}
-    init SOC.Memory.Flash_0                  {Nothing}
-    init SOC.Memory.Ram_0                    {Nothing}
+   init SOC.IO.UART_0                       {}
+   init SOC.Memory.Flash_0                  {}
+   init SOC.Memory.Ram_0                    {}
 
-    init SOC.IO.TEST                         {Nothing}
+   init SOC.IO.TEST                         {}
 
-    init Tools.Elf.Section.SHF_ALLOC         {Nothing}
-    init Tools.Elf.Section.SHF_EXECINSTR     {Nothing}
-    init Tools.Elf.Section.SHF_WRITE         {Nothing}
+   init Tools.Elf.Section.SHF_ALLOC         {}
+   init Tools.Elf.Section.SHF_EXECINSTR     {}
+   init Tools.Elf.Section.SHF_WRITE         {}

--- a/osv/testComplex.dpl
+++ b/osv/testComplex.dpl
@@ -24,12 +24,18 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-module osv.nop:
+module osv.testComplex:
 
 /*
- * The Nop Policy provides no security in the most complicated way possible.
- * The purpose of this policy is to test the system tag initialization and 
- * catch any tags that have not been properly initialized.
+ * The Complex Test policy provides very little security in a complicated 
+ * way.  It is intended to stress test policy compilation, system tag
+ * initialization, and policy execution.
+ *
+ * It does enforce marginally more security than the "none" policy in that
+ * it requires all instructions to be tagged with opgroups.  It will
+ * therefore prevent attacks that write code and attempt to execute it.
+ * This is the minimum level of security it is possible to provide
+ * without use of the __NO_CHECKS escape hatch.
  */
 
 import:
@@ -46,7 +52,7 @@ metadata:
     AllowIO
 
 policy:           // Allow most ops involving regular registers, memory & csrs
-  nopPol =
+  testComplexPol =
      arithGrp(code == [AllowCode], env == [AllowEnv], op1 == [AllowReg], op2 == [AllowReg] -> env = {AllowEnv}, res = {AllowReg})
    ^ immArithGrp(code == [AllowCode], env == [AllowEnv], op1 == [AllowReg] -> env = {AllowEnv}, res = {AllowReg})
    ^ mulDivRemGrp(code == [AllowCode], env == [AllowEnv], op1 == [AllowReg], op2 == [AllowReg] -> env = {AllowEnv}, res = {AllowReg})
@@ -71,7 +77,6 @@ policy:           // Allow most ops involving regular registers, memory & csrs
      // Change privledge mode
    ^ privGrp(code == [AllowCode], env == [AllowEnv] -> env = {AllowEnv})
    
-//  main = nopPol
 
 require:
     init ISA.RISCV.Reg.Env                   {AllowEnv}

--- a/osv/testSimple.dpl
+++ b/osv/testSimple.dpl
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2017-2018 The Charles Stark Draper Laboratory, Inc. and/or Dover Microsystems, Inc.
+ * All rights reserved. 
+ *
+ * Use and disclosure subject to the following license. 
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+module osv.testSimple:
+
+/*
+ * The Simple Test policy provides very little security in a simple way.
+ * It is used to check that the very basics of policy compilation and
+ * execution are still working.
+ *
+ * It does enforce marginally more security than the "none" policy in that
+ * it requires all instructions to be tagged with opgroups.  It will
+ * therefore prevent attacks that write code and attempt to execute it.
+ * This is the minimum level of security it is possible to provide
+ * without use of the __NO_CHECKS escape hatch.
+ */
+
+import:
+      osv.riscv
+
+metadata:
+        Nothing
+
+policy:
+        // a policy that allows anything and contributes no results
+    testSimplePol = branchGrp(code == _, env == _, op1 == _, op2 == _ -> env = env )
+            ^ jumpRegGrp(code == _, env == _, target == _ -> env = env , return = {})
+            ^ jumpGrp(code == _, env == _ -> return = {})
+            ^ loadUpperGrp(code == _, env == _ -> env = env, dest = {})
+            ^ immArithGrp(code == _, env == _, op1 == _ -> env = env, res = {})
+            ^ arithGrp(code == _, env == _, op1 == _, op2 == _ -> env = env, res = {})
+            ^ loadGrp(code == _, env == _, addr == _, mem == _ -> env = env, res = {})
+            ^ storeGrp(code == _, env == _, addr == _, val == _, mem == _ -> env = env, mem = {})
+            ^ mulDivRemGrp(code == _, env == _, op1 == _, op2 == _ -> env = env, res = {})
+            ^ csrGrp(code == _, env == _, op1 == _, csr == _ -> env = env, csr = {}, res = {})
+            ^ csriGrp(code == _, env == _, csr == _ -> env = env, csr = {}, res = {})
+            ^ privGrp(code == _, env == _ -> env = env)
+            ^ systemGrp(code == _, env == _ -> env = env)
+            ^ floatGrp(code == _, env == _ -> env = env)
+            ^ atomicGrp(code == _, env == _ -> env = env)
+
+require:
+    init ISA.RISCV.Reg.Env                   {Nothing}
+    init ISA.RISCV.Reg.Default               {Nothing}
+    init ISA.RISCV.Reg.RZero                 {Nothing}
+    init ISA.RISCV.CSR.Default               {Nothing}
+    init ISA.RISCV.CSR.MTVec                 {Nothing}
+
+    init Tools.Link.MemoryMap.Default        {Nothing}
+    init Tools.Link.MemoryMap.UserHeap       {Nothing}
+    init Tools.Link.MemoryMap.UserStack      {Nothing}
+
+    init SOC.IO.UART_0                       {Nothing}
+    init SOC.Memory.Flash_0                  {Nothing}
+    init SOC.Memory.Ram_0                    {Nothing}
+
+    init SOC.IO.TEST                         {Nothing}
+
+    init Tools.Elf.Section.SHF_ALLOC         {Nothing}
+    init Tools.Elf.Section.SHF_EXECINSTR     {Nothing}
+    init Tools.Elf.Section.SHF_WRITE         {Nothing}

--- a/policy_tests/Makefile
+++ b/policy_tests/Makefile
@@ -20,7 +20,7 @@ qemu_SIM = qemu
 qemu_TESTS = hifive
 qemu_RUNTIME = hifive
 qemu_MODULE = osv.hifive.main
-qemu_POLICIES = heap,none,rwx,stack,threeClass
+qemu_POLICIES = heap,rwx,stack,threeClass,none,testSimple
 qemu_XDIST = -n $(JOBS) # run in parallel
 qemu: CONFIG=qemu
 qemu: all
@@ -30,7 +30,7 @@ renode_SIM = renode
 renode_TESTS = frtos
 renode_RUNTIME = frtos
 renode_MODULE = osv.frtos.main
-renode_POLICIES = heap,none,rwx,stack
+renode_POLICIES = heap,rwx,stack,none,testSimple
 renode_XDIST=
 renode: CONFIG=renode
 renode: all

--- a/policy_tests/conftest.py
+++ b/policy_tests/conftest.py
@@ -134,9 +134,19 @@ def composites(module, policies, simple):
     full_composite_len = len(policies)
     if "none" in policies:
         full_composite_len -= 1
+    if "testSimple" in policies:
+        full_composite_len -= 1
+    if "testComplex" in policies:
+        full_composite_len -= 1
 
     if simple: # single policies or full combination
         return [x[1] for x in r if len(x[0]) == 1 or
-                (len(x[0]) == full_composite_len and not "none" in x[0])]
+                (    (len(x[0]) == full_composite_len)
+                 and (not "none" in x[0])
+                 and (not "testSimple" in x[0])
+                 and (not "testComplex" in x[0]))]
     else: # single policies or any combination without none
-        return [x[1] for x in r if len(x[0]) == 1 or not "none" in x[1]]
+        return [x[1] for x in r if len(x[0]) == 1 or
+                (     (not "none" in x[0])
+                  and (not "testSimple" in x[0])
+                  and (not "testComplex" in x[0]))]


### PR DESCRIPTION
This policy makes use of the __NO_CHECKS policy-language construct added in a
recent version of the policy tool.  This commit also does a bit of
reorganization, giving the innaccurately named "none" and "nop" policies the
more descriptive names "testSimple" and "testComplex".  The "none" policy has
been replaced by the policy that actually does no checking.