### PR TITLE
Heap upstream freertos hifive

### DIFF
--- a/entities/osv.frtos.main.heap.entities.yml
+++ b/entities/osv.frtos.main.heap.entities.yml
@@ -44,8 +44,3 @@
     elf_name: _svfprintf_r
     kind: symbol
     tag_all: true
--
-    name: alert.debugger
-    elf_name: ALERT
-    kind: symbol
-    tag_all: true

--- a/osv/heap.dpl
+++ b/osv/heap.dpl
@@ -42,15 +42,13 @@ metadata:
   DelColor,          // Special memory cell used with RemoveColor
   ModColor,          // Special value used to modify heap cells
   AntiPointer,       // Special Value that eliminates color from pointers
-  SpecialCaseVFPRINTF,  // Mark vprinter code to enable special case hack
-  alert 
+  SpecialCaseVFPRINTF  // Mark vprinter code to enable special case hack
+
 
 policy:
   heapPol =
 // Special case to avoid hacking printf %x
     andiGrp(code == [SpecialCaseVFPRINTF], env == _, op1 == _ -> env = env, res = {})
-
-    ^ storeGrp(mem == [alert], addr == _, code == _, val == _, env == _ -> mem = {alert})
 
 // Handle generic pointer arithmetic
    ^ arithGrp(env == _, op1 == [-(Pointer _)], op2 == [-(Pointer _)] -> env = env, res = {})
@@ -140,8 +138,6 @@ require:
     init SOC.IO.CLINT                        {}
     init SOC.IO.ITIM                         {}
     init SOC.IO.PLIC                         {}
-
-    init alert.debugger {alert}
 
     init dover.Kernel.Code.ApplyTag.ucHeap              {RawHeap}
     init dover.Kernel.Code.ApplyTag.dover_ptr_zero      {ModColor}

--- a/policy_tests/tests/heap/malloc_fails_1.c
+++ b/policy_tests/tests/heap/malloc_fails_1.c
@@ -35,12 +35,6 @@
 // include malloc wrappers
 #include "mem.h"
 
-volatile int ALERT;
-
-int bleh(int stackvar) {
-  printf("stackvar addr = 0x%x\n", &stackvar);
-}
-
 /*
  * Test to allocate memory and check that we can 
  * catch out of bounds accesses.
@@ -50,33 +44,20 @@ int test_main(void)
     uintptr_t *ptr, *write_ptr, *read_ptr;
     volatile uintptr_t dummy;
 
-    int stackvar = 9;
-
-    bleh(stackvar);
-    printf("stackvar = 0x%x\n", &stackvar);
-    
-    printf("addr of read_ptr = 0x%x\n", &read_ptr);
-    
     test_negative(); // identify test as negative (should not complete)
 
     ptr = malloc(8 * sizeof(uintptr_t));
-    ALERT = 3;
     write_ptr = ptr;
 
-    printf("malloced ptr = 0x%x\n", ptr);
-    
     for(int i =0; i < 8;i++){
       *write_ptr = i;
       write_ptr++;
     }
-
-    ALERT = 2;
+	
     read_ptr = ptr -1;
 
     test_begin();
 
-    ALERT = 1;
-    
     dummy = *read_ptr;  // this should fail
 
     // None of the following code should execute


### PR DESCRIPTION
@arunthomas The heap policy is mostly working on upstream. The longer tests still have some nondeterminism but as I've seen them all pass at one time or another, I think its a function of FRTOS context switching... 

@ccasin This patch is an example of an issue we've talked about before with the policy language. The new code does a `mv` from one register to another. When it did that, it discarded important tags... so I changed the "clear the result tag if you do a move" to "keep the result tag if you do a move". Will this break other shit? idk...