### PR TITLE
Increase policy test timeout for long-running benchmark tests

### DIFF
--- a/policy_tests/Makefile
+++ b/policy_tests/Makefile
@@ -54,7 +54,7 @@ COMPOSITE ?= simple
 RULE_CACHE_SIZE ?= 16
 DEBUG ?= no
 
-PYTEST_ARGS ?= --capture=no -v -rsx --timeout=180 --timeout-method=thread $(ERROR_MSGS) --sim=$(SIM) --isp_debug=$(DEBUG) --test=$(TESTS) --rule_cache=$(RULE_CACHE) --rule_cache_size=$(RULE_CACHE_SIZE) --runtime=$(RUNTIME) --policies=$(POLICIES) --composite=$(COMPOSITE) --module=$(MODULE)
+PYTEST_ARGS ?= --capture=no -v -rsx --timeout=360 --timeout-method=thread $(ERROR_MSGS) --sim=$(SIM) --isp_debug=$(DEBUG) --test=$(TESTS) --rule_cache=$(RULE_CACHE) --rule_cache_size=$(RULE_CACHE_SIZE) --runtime=$(RUNTIME) --policies=$(POLICIES) --composite=$(COMPOSITE) --module=$(MODULE)
 
 # RIPE Tests
 RIPE_CONFIGS := ripe/ripe_configs.py


### PR DESCRIPTION
Some tests currently run past the 180s timeout, an increase to 360s will allow longer tests to run.