### PR TITLE
Bitcount: enable frtos

### DIFF
--- a/policy_tests/test_groups.py
+++ b/policy_tests/test_groups.py
@@ -81,7 +81,6 @@ class frtos(AllTests):
                                   "heap-ppac-userType/webapp_patient_info_leak_fails",
                                   "userType/webapp_double_usr_set",
                                   "password/webapp_password_leak",
-                                  "bitcount",
                                  ]
                                  )]
 

--- a/policy_tests/tests/bitcount/Makefile.frtos
+++ b/policy_tests/tests/bitcount/Makefile.frtos
@@ -1,0 +1,2 @@
+include ../isp-runtime-frtos.mk
+include common.mk

--- a/policy_tests/tests/bitcount/common.mk
+++ b/policy_tests/tests/bitcount/common.mk
@@ -8,7 +8,7 @@ LDFLAGS += -lm
 INCLUDES += $(ISP_INCLUDES)
 INCLUDES += -I$(TEST_ROOT_DIR)
 
-SOURCES := bitcnt_1.c bitcnt_2.c bitcnt_3.c bitcnt_4.c bitcnts.c bitfiles.c bitstrng.c bstr_i.c
+SOURCES := bitcnt_1.c bitcnt_2.c bitcnt_3.c bitcnt_4.c bitcnts.c bitstrng.c bstr_i.c
 SOURCES += $(TEST_ROOT_DIR)/test_status.c
 
 OBJECTS := $(patsubst %.c,%.o,$(SOURCES))


### PR DESCRIPTION
Adds the ability to run the bitcount test on frtos. There were initially build errors which have been fixed after the floating point fix in riscv-gnu-toolchain.