### PR TITLE
Re-enable most of the disabled tests

### DIFF
--- a/entities/osv.bare.main.heap.entities.yml
+++ b/entities/osv.bare.main.heap.entities.yml
@@ -39,9 +39,3 @@
     elf_name: dover_ptr_untag
     kind: symbol
     tag_all: true
--
-    name: dover.Tools.RTL._vfprintf_r
-    elf_name: _svfprintf_r
-    kind: symbol
-    tag_all: true
-    optional: true

--- a/entities/osv.bare.main.stack.entities.yml
+++ b/entities/osv.bare.main.stack.entities.yml
@@ -1,0 +1,7 @@
+-
+    name: dover.Tools.RTL.longjmp
+    elf_name: longjmp
+    kind: symbol
+    tag_all: true
+    optional: true
+

--- a/entities/osv.frtos.main.heap.entities.yml
+++ b/entities/osv.frtos.main.heap.entities.yml
@@ -39,8 +39,3 @@
     elf_name: dover_ptr_untag
     kind: symbol
     tag_all: true
--
-    name: dover.Tools.RTL._vfprintf_r
-    elf_name: _svfprintf_r
-    kind: symbol
-    tag_all: true

--- a/entities/osv.frtos.main.stack.entities.yml
+++ b/entities/osv.frtos.main.stack.entities.yml
@@ -1,0 +1,7 @@
+-
+    name: dover.Tools.RTL.longjmp
+    elf_name: longjmp
+    kind: symbol
+    tag_all: true
+    optional: true
+

--- a/osv/cfi.dpl
+++ b/osv/cfi.dpl
@@ -48,7 +48,7 @@ policy:
     mretGrp ( env == _ -> env = {} )
 
      // Case for not checking cfi (asm code)
-    ^ allGrp    (code == [+NoCFI], env == _ -> env = env )
+    ^ allGrp    (code == [+NoCFI,-Target], env == _ -> env = env )
          // cases for landing on a jump (bounce)
     ^ branchGrp (code == [Target], env == [Jumping] -> env = {Jumping})
     ^ jumpGrp   (code == [Target], env == [Jumping] -> env = {Jumping}, return = {})
@@ -60,7 +60,7 @@ policy:
     ^ allGrp    (code == [+Target], env == [+Jumping] -> env = env[-Jumping])
        // Case for normal execution
     ^ allGrp    (env == [-Jumping] -> env = env)
-    ^ allGrp (-> fail "Illegal control flow detected")
+    ^ allGrp (-> fail "cfi: Illegal control flow detected")
 
     main = cfiPol
 
@@ -74,6 +74,9 @@ require:
     init llvm.CFI_Call-Tgt                   {Target}
     init llvm.CFI_Branch-Tgt                 {Target}
     init llvm.CFI_Return-Tgt                 {Target}
+    init llvm.CFI_Call-Instr                 {NoCFI}
+    init llvm.CFI_Branch-Instr               {NoCFI}
+    init llvm.CFI_Return-Instr               {NoCFI}
     init llvm.NoCFI                          {NoCFI}
     
     init dover.Kernel.MemoryMap.Default       {}

--- a/osv/heap.dpl
+++ b/osv/heap.dpl
@@ -46,11 +46,8 @@ metadata:
   
 policy:
   heapPol =
-// Special case to avoid hacking printf %x
-    andiGrp(code == [SpecialCaseVFPRINTF], env == _, op1 == _ -> env = env, res = {})
-
 // Handle generic pointer arithmetic
-   ^ arithGrp(env == _, op1 == [-(Pointer _)], op2 == [-(Pointer _)] -> env = env, res = {})
+     arithGrp(env == _, op1 == [-(Pointer _)], op2 == [-(Pointer _)] -> env = env, res = {})
 // since the previous rule didn't fire check for AntiPointer
    ^ arithGrp(env == _, op1 == [+AntiPointer], op2 == _ -> env = env, res = {})
    ^ arithGrp(env == _, op1 == _, op2 == [+AntiPointer] -> env = env, res = {})

--- a/osv/riscv.dpl
+++ b/osv/riscv.dpl
@@ -81,6 +81,7 @@ group:
         bgeu
         jal
         jalr
+        ecall
 
     grp pcGrp(-> RD:dest)
         auipc

--- a/policy_tests/conftest.py
+++ b/policy_tests/conftest.py
@@ -54,6 +54,10 @@ def composite(request):
 def debug(request):
     return 'yes' == request.config.getoption('--isp_debug')
 
+@pytest.fixture
+def timeout(request):
+    return request.config.getoption('--timeout')
+
 def pytest_generate_tests(metafunc):
 
     if 'policy' in metafunc.fixturenames:

--- a/policy_tests/run_unit_tests.py
+++ b/policy_tests/run_unit_tests.py
@@ -25,8 +25,6 @@ def incompatibleReason(test, policy):
 def xfailReason(test, policy, runtime):
     if test in ["hello_works_2"] and "testContext" in policy and not "contextswitch" in policy:
         return "hello_works_2 should fail with testContext unless the contextswitch policy is also there."
-    if test in ["fft"] and "heap" in policy and (runtime == "frtos"):
-        return "known to fail due to heap policy not playing nice with printf functions"
 
     return None
 

--- a/policy_tests/run_unit_tests.py
+++ b/policy_tests/run_unit_tests.py
@@ -23,8 +23,6 @@ def incompatibleReason(test, policy):
     return None
 
 def xfailReason(test, policy, runtime):
-    if test in ["longjump_works_1"] and "stack" in policy and (runtime == "frtos"):
-        return "known to fail"
     if test in ["hello_works_2"] and "testContext" in policy and not "contextswitch" in policy:
         return "hello_works_2 should fail with testContext unless the contextswitch policy is also there."
     if test in ["fft"] and "heap" in policy and (runtime == "frtos"):

--- a/policy_tests/run_unit_tests.py
+++ b/policy_tests/run_unit_tests.py
@@ -23,25 +23,12 @@ def incompatibleReason(test, policy):
     return None
 
 def xfailReason(test, policy, runtime):
-    if "longjump" in test:
-        return "longjump test known to be broken"
-    if "hello_works_2" in test and "testContext" in policy and not "contextswitch" in policy:
+    if test in ["longjump_works_1"] and "stack" in policy and (runtime == "frtos"):
+        return "known to fail"
+    if test in ["hello_works_2"] and "testContext" in policy and not "contextswitch" in policy:
         return "hello_works_2 should fail with testContext unless the contextswitch policy is also there."
-
-    long_tests = [
-        "link_list_works_1",
-        "string_works_1",
-        "aes",
-        "bitcount",
-        "fft",
-        "qsort",
-        "rc4",
-        "rsa",
-        "sha",
-        "stringsearch",
-    ]
-    if test in long_tests and "heap" in policy and (runtime == "frtos"):
-        return "long-running tests known to fail with heap policy on frtos due to context switching"
+    if test in ["fft"] and "heap" in policy and (runtime == "frtos"):
+        return "known to fail due to heap policy not playing nice with printf functions"
 
     return None
 

--- a/policy_tests/test_groups.py
+++ b/policy_tests/test_groups.py
@@ -75,25 +75,12 @@ class webapp(AllTests):
     ]
 
 
-# XXX: Re-enable Long-running tests once passing"
 class frtos(AllTests):
     tests = [test for test in AllTests.tests
                       if not any(test in s for s in
-                                 ["timer_works_1",
-                                  "coremark",
-                                  "stanford_int_treesort_fixed",
-                                  "ping_pong_works_1",
-                                  "malloc_prof_1",
-                                  "malloc_prof_2",
-                                  "taint/tainted_print_fails",
-                                  "webapp_doctor_user_works",
-                                  "webapp_admin_user_works",
-                                  "webapp_patient_read_works",
-                                  "heap-ppac-userType/webapp_unauth_doctor_routine_fails",
+                                 [
                                   "heap-ppac-userType/webapp_patient_info_leak_fails",
-                                  "userType/webapp_double_usr_set",
                                   "password/webapp_password_leak",
-                                  "bitcount",
 				  "dhrystone/dhrystone-baremetal",
                                  ]
                                  )]

--- a/policy_tests/tests/printf_works_1.c
+++ b/policy_tests/tests/printf_works_1.c
@@ -46,9 +46,9 @@ int test_main(void)
     test_begin();
 
     // do some random work for no good reason
-    ptr = malloc(3 * sizeof(uintptr_t));
+    ptr = malloc(4 * sizeof(uintptr_t));
     write_ptr = ptr;
-    for(int i =0; i < 3;i++){
+    for(int i =0; i < 4;i++){
       *write_ptr = i;
       write_ptr++;
     }	
@@ -59,6 +59,8 @@ int test_main(void)
     t_printf("test_printf_works1: print         int ptr @ %ld = %ld\n", read_ptr, *read_ptr );
     read_ptr++;
     t_printf("test_printf_works1: print         hex ptr @ %lx = %ld\n", read_ptr, *read_ptr );
+    read_ptr++;
+    t_printf("test_printf_works1: print         oct ptr @ %lo = %ld\n", read_ptr, *read_ptr );
     read_ptr++;
     t_printf("test_printf_works1: print     pointer ptr @ %p = %ld\n", read_ptr, *read_ptr );
     


### PR DESCRIPTION
Along with reenabling tests, also run the xfail tests and test that they actually fail.

Since we're reenabling longer tests, make sure that if they don't finish in the given time, that they are killed, not left running.

A few of the disabled tests were failing. 85b6b44 fixes some of these. Issue #85 explains the remaining two.