### PR TITLE
Re-enable coremark and dhrystone

### DIFF
--- a/policy_tests/Makefile
+++ b/policy_tests/Makefile
@@ -16,8 +16,6 @@ all: build-dirs run-tests
 
 # Arguments specific to running on an FPGA
 BITSTREAM ?= $(ISP_PREFIX)/vcu118/bitstreams/soc_chisel_pipe_p1.bit
-AP_TTY ?= /dev/ttyUSB1
-PEX_TTY ?= /dev/ttyUSB0
 
 # Standard build configurations can be listed here:
 #   variable format: {config_name}_{VAR}
@@ -54,7 +52,7 @@ bare-vcu118_MODULE = osv.bare.main
 bare-vcu118_GPOLICIES = 
 bare-vcu118_POLICIES = rwx
 bare-vcu118_XDIST = -n $(JOBS) # run in parallel
-bare-vcu118_PYTEST_ARGS = --extra=+bitstream=$(BITSTREAM),+ap-tty=$(AP_TTY),+pex-tty=$(PEX_TTY)
+bare-vcu118_PYTEST_ARGS = --extra=+bitstream=$(BITSTREAM),+pex-debug
 bare-vcu118: CONFIG=bare-vcu118
 bare-vcu118: all
 
@@ -77,7 +75,7 @@ frtos-vcu118_MODULE = osv.frtos.main
 frtos-vcu118_GPOLICIES = contextswitch
 frtos-vcu118_POLICIES = cfi,heap,rwx,stack,taint,threeClass,none,testSimple,testContext
 frtos-vcu118_XDIST= -n $(JOBS) # run in parallel
-frtos-vcu118_PYTEST_ARGS = --extra=+bitstream=$(BITSTREAM),+ap-tty=$(AP_TTY),+pex-tty=$(PEX_TTY)
+frtos-vcu118_PYTEST_ARGS = --extra=+bitstream=$(BITSTREAM),+pex-debug
 frtos-vcu118: CONFIG=frtos-vcu118
 frtos-vcu118: all
 

--- a/policy_tests/test_groups.py
+++ b/policy_tests/test_groups.py
@@ -61,6 +61,7 @@ class AllTests:
 	"blowfish",
 	"limits",
 	"picojpeg",
+        "coremark",
     ]
 
 class webapp(AllTests):

--- a/policy_tests/test_groups.py
+++ b/policy_tests/test_groups.py
@@ -62,6 +62,7 @@ class AllTests:
 	"limits",
 	"picojpeg",
         "coremark",
+        "dhrystone",
     ]
 
 class webapp(AllTests):

--- a/policy_tests/tests/coremark/core_portme.c
+++ b/policy_tests/tests/coremark/core_portme.c
@@ -1,8 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "coremark.h"
-#include "platform.h"
-#include "encoding.h"
 
 #if VALIDATION_RUN
 	volatile ee_s32 seed1_volatile=0x3415;
@@ -29,12 +27,12 @@ static CORE_TICKS t0, t1;
 
 void start_time(void)
 {
-  t0 = get_timer_value();
+  t0 = isp_get_time_usec();
 }
 
 void stop_time(void)
 {
-  t1 = get_timer_value();
+  t1 = isp_get_time_usec();
 }
 
 CORE_TICKS get_time(void)
@@ -47,6 +45,6 @@ secs_ret time_in_secs(CORE_TICKS ticks)
   // scale timer down to avoid uint64_t -> double conversion in RV32
   int scale = 256;
   uint32_t delta = ticks / scale;
-  uint32_t freq = get_timer_freq() / scale;
+  uint32_t freq = isp_get_timer_freq() / scale;
   return delta / (double)freq;
 }


### PR DESCRIPTION
- requires a patch to hope-tools to expose isp_get_timer_freq() in libisp (https://github.com/draperlaboratory/hope-tools/pull/60)
- also gets rid of explicit TTY settings in the VCU118 tests since TTYs are now autodetected