### PR TITLE
Fix coremark test

### DIFF
--- a/policy_tests/test_groups.py
+++ b/policy_tests/test_groups.py
@@ -84,6 +84,8 @@ class frtos(AllTests):
                                   "heap-ppac-userType/webapp_patient_info_leak_fails",
                                   "password/webapp_password_leak",
 				  "dhrystone/dhrystone-baremetal",
+                                  "fft",
+                                  "timer_works_1",
                                  ]
                                  )]
 
@@ -94,6 +96,8 @@ class bare(AllTests):
                                  ["ping_pong_works_1",
                                   "dhrystone/dhrystone-baremetal",
 				  "hello_works_2",
+                                  "fft",
+                                  "timer_works_1",
                                  ]
                                  )]
 

--- a/policy_tests/tests/coremark/coremark.h
+++ b/policy_tests/tests/coremark/coremark.h
@@ -41,7 +41,7 @@ Original Author: Shay Gal-on
 #include <stdio.h>
 #endif
 #if HAS_PRINTF
-#define ee_printf printf
+#define ee_printf t_printf
 #endif
 
 /* Actual benchmark execution in iterate */


### PR DESCRIPTION
Switching to t_printf allows the coremark test to pass.