### PR TITLE
Remove ModColor tag from memory at the end of malloc

### DIFF
--- a/osv/heap.dpl
+++ b/osv/heap.dpl
@@ -85,6 +85,10 @@ policy:
              -> res = {}, env = env )
              
 // Any other write to pallette needs to maintain its tags
+   ^ storeGrp(   code == [+ApplyColor], mem == [+ModColor], env == _, val == {}
+              -> mem = mem[-ModColor], env = env )
+   ^ storeGrp(   code == [+RemoveColor], mem == [+ModColor], env == _, val == {}
+              -> mem = mem[-ModColor], env = env )
    ^ storeGrp(   code == _, mem == [+NewColor], env == _
               -> mem = mem, env = env )
    ^ storeGrp(   code == _, mem == [+DelColor], env == _


### PR DESCRIPTION
Add policy code that removes the `ModColor` tag from memory written by code that has the `RemoveColor` tag. Goes along with draperlaboratory/hope-freedom-e-sdk#23.