### PR TITLE
Fix RC4 tests

### DIFF
--- a/policy_tests/tests/rc4/rc4test.c
+++ b/policy_tests/tests/rc4/rc4test.c
@@ -6,8 +6,8 @@
 #include "test_status.h"
 #include "test.h"
 
-unsigned char edata[TESTDATALEN];
-unsigned char udata[TESTDATALEN];
+static unsigned char edata[TESTDATALEN];
+static unsigned char udata[TESTDATALEN];
 
 /*        This code illustrates a sample implementation
 *                 of the Arcfour algorithm


### PR DESCRIPTION
This commit fixes a bug where the RC4 test overwrote test status flags, causing the test to be marked as failing.