### PR TITLE
Support SBRK

### DIFF
--- a/entities/osv.rwx.entities.yml
+++ b/entities/osv.rwx.entities.yml
@@ -1,0 +1,6 @@
+-
+    name: dover.Kernel.Code.ApplyTag.sbrk_zero
+    elf_name: sbrk_zero
+    kind: symbol
+    tag_all: true
+    optional: true

--- a/osv/heap.dpl
+++ b/osv/heap.dpl
@@ -151,6 +151,8 @@ require:
     init SOC.Memory.BRAM_CTRL_0              {}
     init SOC.Memory.DMA_0                    {}
     init SOC.Memory.QSPI_1                   {}
+
+    init SOC.MAILBOX                         {}
     
     init dover.Kernel.Code.ApplyTag.ucHeap              {RawHeap}
     init dover.Kernel.Code.ApplyTag.dover_ptr_zero      {ModColor}

--- a/osv/none.dpl
+++ b/osv/none.dpl
@@ -59,6 +59,8 @@ require:
    init SOC.IO.GPIO_1                       {}
    init SOC.IO.Ethernet_0                   {}
 
+   init SOC.MAILBOX                         {}
+
    init SOC.Memory.BRAM_CTRL_0              {}
    init SOC.Memory.DMA_0                    {}
    init SOC.Memory.QSPI_1                   {}

--- a/osv/rwx.dpl
+++ b/osv/rwx.dpl
@@ -45,14 +45,14 @@ metadata:
 
 policy:
   rwxPol =
-      loadGrp(mem == [-Rd] -> fail "read violation")
+      // Initialize or delete tags for memory when sbrk allocates or deallocates it
+      storeGrp(code == [+Ex], val == [+sbrk], env == _, mem == [-Rd, -Wr] -> mem = mem[+Rd, +Wr], env = env)
+    ^ loadGrp(code == [+Ex], env == _, mem == [+Rd, +sbrk] -> res = {sbrk}, env = env)
+    ^ storeGrp(code == [+Ex], val == [+sbrk], env == _, mem == [+Rd, +Wr] -> mem = {})
+
+    ^ loadGrp(mem == [-Rd] -> fail "read violation")
     ^ storeGrp(mem == [-Wr] -> fail "write violation")
     ^ allGrp(code == [-Ex] -> fail "execute violation")
-
-    // Initialize or delete tags for memory when sbrk allocates or deallocates it
-    ^ loadGrp(code == [+Ex], env == _, mem == [+Rd, +sbrk] -> res = {sbrk}, env = env)
-    ^ storeGrp(code == [+Ex], val == [+sbrk], env == _, mem == [-Rd, -Wr] -> mem = mem[+Rd, +Wr], env = env)
-    ^ storeGrp(code == [+Ex], val == [+sbrk], env == _, mem == [+Rd, +Wr] -> mem = {})
 
     ^ loadGrp  (code == [+Ex], env == _, mem == [+Rd] -> res = {}, env = env)
     ^ storeGrp (code == [+Ex], env == _, mem == [+Wr] -> mem = mem, env = env)
@@ -89,6 +89,8 @@ require:
     init SOC.IO.GPIO_0                       {Rd, Wr}
     init SOC.IO.GPIO_1                       {Rd, Wr}
     init SOC.IO.Ethernet_0                   {Rd, Wr}
+
+    init SOC.MAILBOX                         {Rd, Wr}
 
     init SOC.Memory.BRAM_CTRL_0              {Rd, Wr}
     init SOC.Memory.DMA_0                    {Rd, Wr}

--- a/osv/rwx.dpl
+++ b/osv/rwx.dpl
@@ -39,7 +39,8 @@ import:
 metadata:
 	Rd,
 	Wr,
-	Ex
+	Ex,
+  sbrk
 
 
 policy:
@@ -47,6 +48,12 @@ policy:
       loadGrp(mem == [-Rd] -> fail "read violation")
     ^ storeGrp(mem == [-Wr] -> fail "write violation")
     ^ allGrp(code == [-Ex] -> fail "execute violation")
+
+    // Initialize or delete tags for memory when sbrk allocates or deallocates it
+    ^ loadGrp(code == [+Ex], env == _, mem == [+Rd, +sbrk] -> res = {sbrk}, env = env)
+    ^ storeGrp(code == [+Ex], val == [+sbrk], env == _, mem == [-Rd, -Wr] -> mem = mem[+Rd, +Wr], env = env)
+    ^ storeGrp(code == [+Ex], val == [+sbrk], env == _, mem == [+Rd, +Wr] -> mem = {})
+
     ^ loadGrp  (code == [+Ex], env == _, mem == [+Rd] -> res = {}, env = env)
     ^ storeGrp (code == [+Ex], env == _, mem == [+Wr] -> mem = mem, env = env)
     ^ allGrp(code == [+Ex], env == _ -> env = env)
@@ -90,5 +97,7 @@ require:
     init elf.Section.SHF_ALLOC         {Rd}
     init elf.Section.SHF_EXECINSTR     {Ex}
     init elf.Section.SHF_WRITE         {Rd, Wr}
+
+    init dover.Kernel.Code.ApplyTag.sbrk_zero {Rd, sbrk}
 
 


### PR DESCRIPTION
Adds a new tag to the rwx policy that allows the AP to use the `sbrk` system call to expand the data segment of its memory.  It works similarly to `malloc`: a special location in memory is tagged with a special value that is loaded into an AP register after expanding the data segment, which is used to signal the PEX to initialize tags in the new segment (or remove them if the data segment is being shrunk).