### PR TITLE
Fix offset_free_fails_1 64-Bit Hang

### DIFF
--- a/policy_tests/tests/heap/offset_free_fails_1.c
+++ b/policy_tests/tests/heap/offset_free_fails_1.c
@@ -50,7 +50,7 @@ int test_main(void)
 
   test_begin(); // everything should work up to here
 
-  free(heap_buffer+4); // invalid chunk, should fail
+  free(heap_buffer+sizeof(uintptr_t)); // invalid chunk, should fail
 
   test_error("test_offset_free_fails_1: Error this should not execute\n");  
 


### PR DESCRIPTION
offset_free_fails_1 hard-codes an increment of its allocated pointer by 4 when it tries to free it (to check if the PEX detects that as illegal).  This works fine on 32-bit systems, but on 64-bit ones the `free` function uses `ld` instructions based off the pointer it's given, so when that pointer is unaligned and the system doesn't support misaligned loads, the AP will encounter a fault.  Additionally, because data is tagged at 64-bit granularity on a 64-bit system, the incremented pointer maps to the same tag as the original pointer, so the PEX doesn't detect the policy violation.

By changing the increment to `sizeof(uintptr_t)`, it will increment the correct amount, `free` will execute normally, and the PEX will correctly detect the policy violation.