### PR TITLE
Fix ELF Section Tagging in cfi and threeClass

### DIFF
--- a/osv/cfi.dpl
+++ b/osv/cfi.dpl
@@ -105,3 +105,7 @@ require:
     init SOC.IO.CLINT                        {}
     init SOC.IO.ITIM                         {}
     init SOC.IO.PLIC                         {}
+
+	init elf.Section.SHF_ALLOC               {}
+	init elf.Section.SHF_EXECINSTR           {}
+	init elf.Section.SHF_WRITE               {}

--- a/osv/threeClass.dpl
+++ b/osv/threeClass.dpl
@@ -124,3 +124,7 @@ require:
     init Tools.Elf.Section.SHF_ALLOC         {}
     init Tools.Elf.Section.SHF_EXECINSTR     {}
     init Tools.Elf.Section.SHF_WRITE         {}
+
+	init elf.Section.SHF_ALLOC               {}
+	init elf.Section.SHF_EXECINSTR           {}
+	init elf.Section.SHF_WRITE               {}


### PR DESCRIPTION
Line 97 of gen_tag_info ensures that ELF sections are only tagged if the string "elf" appears in an `init` statement in the `require` section of a policy file (typically appearing as `init elf.Section.SHF_*`).  The cfi and threeClass policies do not have this; rather, they have `init dover.Kernel.Code.ElfSection.SHF_*`, which doesn't pass the test.

This line was added in 2019, so it's not clear why the tests worked in the past, but adding the proper `init elf.Section.SHF_*` statements causes it to work again.