### PR TITLE
Add test for pr-metadata-loc-fix

### DIFF
--- a/policy_tests/test_groups.py
+++ b/policy_tests/test_groups.py
@@ -40,6 +40,7 @@ class AllTests:
         "heap/offset_free_fails_1",
         "stack/stack_fails_1",
         "threeClass/jump_data_fails_1",
+        "threeClass/jump_non_calltgt_fails_1",
         "threeClass/call_fails_1",
         "taint/tainted_print_fails",
         "dhrystone/dhrystone-baremetal",

--- a/policy_tests/tests/threeClass/jump_non_calltgt_fails_1.c
+++ b/policy_tests/tests/threeClass/jump_non_calltgt_fails_1.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2017-2018 The Charles Stark Draper Laboratory, Inc. and/or Dover Microsystems, Inc.
+ * All rights reserved. 
+ *
+ * Use and disclosure subject to the following license. 
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "test_status.h"
+#include "test.h"
+
+
+/*
+ * Test to make sure calls to instructions without Call-Tgt metadata fail.
+ * This is very contrived and unlikely to be of use to an attacker,
+ * but is useful to test anyway since the bug happens due to improper tagging.
+ */
+int magic(int);
+__attribute__((noinline)) int test(int a) {
+  int x = a + 5;
+  asm volatile("magic:":"+r"(x));
+  return x * 2;
+}
+
+int test_main(void)
+  {
+    test_negative(); // identify test as negative (will not complete)
+
+    // this should work fine
+    test(1234);
+    test_pass();
+
+    test_begin();
+
+    // this should fail
+    magic(1234);
+    t_printf("CFI jump_non_calltgt_fails_1 Test - should not execute this\n");
+
+    return test_done();
+  }
+


### PR DESCRIPTION
This adds a test to confirm that [pr-metadata-loc-fix](https://github.com/draperlaboratory/hope-llvm-project/pull/11) works as intended.