### PR TITLE
Stall Counters

### DIFF
--- a/entities/SOC/miv_ents.yml
+++ b/entities/SOC/miv_ents.yml
@@ -1,9 +1,9 @@
 -
-  name: SOC.IO.UART_0
+  name: SOC.MMIO.UART_0
   kind: soc
 -
   name: SOC.Memory.Flash_0
   kind: soc
 -
-  name: SOC.IO.TEST
+  name: SOC.MMIO.TEST
   kind: soc

--- a/osv/cfi.dpl
+++ b/osv/cfi.dpl
@@ -96,14 +96,14 @@ require:
     init dover.Kernel.Code.ElfSection.SHF_ALLOC     {}
     init dover.Kernel.Code.ElfSection.SHF_EXECINSTR {}
 
-    init SOC.IO.UART_0                       {}
+    init SOC.MMIO.UART_0                       {}
     init SOC.Memory.Flash_0                  {}
     init SOC.Memory.Ram_0                    {}
 
-    init SOC.IO.TEST                         {}
-    init SOC.IO.CLINT                        {}
-    init SOC.IO.ITIM                         {}
-    init SOC.IO.PLIC                         {}
+    init SOC.MMIO.TEST                         {}
+    init SOC.MMIO.CLINT                        {}
+    init SOC.MMIO.ITIM                         {}
+    init SOC.MMIO.PLIC                         {}
 
 	init elf.Section.SHF_ALLOC               {}
 	init elf.Section.SHF_EXECINSTR           {}

--- a/osv/contextswitch.dpl
+++ b/osv/contextswitch.dpl
@@ -68,15 +68,15 @@ require:
     init Tools.Link.MemoryMap.UserHeap       {}
     init Tools.Link.MemoryMap.UserStack      {}
 
-    init SOC.IO.UART_0                       {}
+    init SOC.MMIO.UART_0                       {}
     init SOC.Memory.Flash_0                  {}
     init SOC.Memory.Ram_0                    {}
 
-    init SOC.IO.TEST                         {}
-    init SOC.IO.CLINT                        {}
-    init SOC.IO.ITIM                         {}
-    init SOC.IO.PLIC                         {}
-    init SOC.IO.GEM0                         {}
+    init SOC.MMIO.TEST                         {}
+    init SOC.MMIO.CLINT                        {}
+    init SOC.MMIO.ITIM                         {}
+    init SOC.MMIO.PLIC                         {}
+    init SOC.MMIO.GEM0                         {}
 
     init elf.Section.SHF_ALLOC         {}
     init elf.Section.SHF_EXECINSTR     {}

--- a/osv/cpi.dpl
+++ b/osv/cpi.dpl
@@ -82,14 +82,14 @@ require:
     init Tools.Link.MemoryMap.UserHeap       {}
     init Tools.Link.MemoryMap.UserStack      {}
 
-    init SOC.IO.UART_0                       {}
+    init SOC.MMIO.UART_0                       {}
     init SOC.Memory.Flash_0                  {}
     init SOC.Memory.Ram_0                    {}
 
-    init SOC.IO.TEST                         {}
-    init SOC.IO.CLINT                        {}
-    init SOC.IO.ITIM                         {}
-    init SOC.IO.PLIC                         {}
+    init SOC.MMIO.TEST                         {}
+    init SOC.MMIO.CLINT                        {}
+    init SOC.MMIO.ITIM                         {}
+    init SOC.MMIO.PLIC                         {}
    
     init Tools.Elf.Section.SHF_ALLOC         {}
     init Tools.Elf.Section.SHF_EXECINSTR     {}

--- a/osv/globalallow.dpl
+++ b/osv/globalallow.dpl
@@ -48,15 +48,15 @@ require:
     init Tools.Link.MemoryMap.UserHeap       {}
     init Tools.Link.MemoryMap.UserStack      {}
 
-    init SOC.IO.UART_0                       {}
+    init SOC.MMIO.UART_0                       {}
     init SOC.Memory.Flash_0                  {}
     init SOC.Memory.Ram_0                    {}
 
-    init SOC.IO.TEST                         {}
-    init SOC.IO.CLINT                        {}
-    init SOC.IO.ITIM                         {}
-    init SOC.IO.PLIC                         {}
-    init SOC.IO.GEM0                         {}
+    init SOC.MMIO.TEST                         {}
+    init SOC.MMIO.CLINT                        {}
+    init SOC.MMIO.ITIM                         {}
+    init SOC.MMIO.PLIC                         {}
+    init SOC.MMIO.GEM0                         {}
 
     init elf.Section.SHF_ALLOC         {}
     init elf.Section.SHF_EXECINSTR     {}

--- a/osv/globalfail.dpl
+++ b/osv/globalfail.dpl
@@ -48,15 +48,15 @@ require:
     init Tools.Link.MemoryMap.UserHeap       {}
     init Tools.Link.MemoryMap.UserStack      {}
 
-    init SOC.IO.UART_0                       {}
+    init SOC.MMIO.UART_0                       {}
     init SOC.Memory.Flash_0                  {}
     init SOC.Memory.Ram_0                    {}
 
-    init SOC.IO.TEST                         {}
-    init SOC.IO.CLINT                        {}
-    init SOC.IO.ITIM                         {}
-    init SOC.IO.PLIC                         {}
-    init SOC.IO.GEM0                         {}
+    init SOC.MMIO.TEST                         {}
+    init SOC.MMIO.CLINT                        {}
+    init SOC.MMIO.ITIM                         {}
+    init SOC.MMIO.PLIC                         {}
+    init SOC.MMIO.GEM0                         {}
 
     init elf.Section.SHF_ALLOC         {}
     init elf.Section.SHF_EXECINSTR     {}

--- a/osv/heap.dpl
+++ b/osv/heap.dpl
@@ -133,19 +133,19 @@ require:
     init elf.Section.SHF_EXECINSTR     {}
     init elf.Section.SHF_WRITE         {}
 
-    init SOC.IO.UART_0                       {}
+    init SOC.MMIO.UART_0                       {}
     init SOC.Memory.Flash_0                  {}
     init SOC.Memory.Ram_0                    {}
 
-    init SOC.IO.TEST                         {}
-    init SOC.IO.CLINT                        {}
-    init SOC.IO.ITIM                         {}
-    init SOC.IO.PLIC                         {}
-    init SOC.IO.GEM0                         {}
-    init SOC.IO.I2C_0                        {}
-    init SOC.IO.GPIO_0                       {}
-    init SOC.IO.GPIO_1                       {}
-    init SOC.IO.Ethernet_0                   {}
+    init SOC.MMIO.TEST                         {}
+    init SOC.MMIO.CLINT                        {}
+    init SOC.MMIO.ITIM                         {}
+    init SOC.MMIO.PLIC                         {}
+    init SOC.MMIO.GEM0                         {}
+    init SOC.MMIO.I2C_0                        {}
+    init SOC.MMIO.GPIO_0                       {}
+    init SOC.MMIO.GPIO_1                       {}
+    init SOC.MMIO.Ethernet_0                   {}
 
     init SOC.Memory.BRAM_CTRL_0              {}
     init SOC.Memory.DMA_0                    {}

--- a/osv/loader.dpl
+++ b/osv/loader.dpl
@@ -119,17 +119,17 @@ require:
     init Tools.Link.MemoryMap.UserHeap       {}
     init Tools.Link.MemoryMap.UserStack      {}
 
-    init SOC.IO.MROM                         {}
-    init SOC.IO.UART_0                       {}
+    init SOC.MMIO.MROM                         {}
+    init SOC.MMIO.UART_0                       {}
     init SOC.Memory.Flash_0                  {}
     init SOC.Memory.Ram_0                    {}
 
-    init SOC.IO.DEBUG                        {}
-    init SOC.IO.TEST                         {}
-    init SOC.IO.CLINT                        {}
-    init SOC.IO.ITIM                         {}
-    init SOC.IO.GEM0                         {}
-    init SOC.IO.AON                          {}
+    init SOC.MMIO.DEBUG                        {}
+    init SOC.MMIO.TEST                         {}
+    init SOC.MMIO.CLINT                        {}
+    init SOC.MMIO.ITIM                         {}
+    init SOC.MMIO.GEM0                         {}
+    init SOC.MMIO.AON                          {}
 
     init elf.Section.SHF_ALLOC         {}
     init elf.Section.SHF_EXECINSTR     {}

--- a/osv/none.dpl
+++ b/osv/none.dpl
@@ -47,19 +47,19 @@ require:
    init Tools.Link.MemoryMap.UserHeap       {}
    init Tools.Link.MemoryMap.UserStack      {}
 
-   init SOC.IO.UART_0                       {}
+   init SOC.MMIO.UART_0                       {}
    init SOC.Memory.Flash_0                  {}
    init SOC.Memory.Ram_0                    {}
 
-   init SOC.IO.TEST                         {}
-   init SOC.IO.CLINT                        {}
-   init SOC.IO.ITIM                         {}
-   init SOC.IO.PLIC                         {}
-   init SOC.IO.GEM0                         {}
-   init SOC.IO.I2C_0                        {}
-   init SOC.IO.GPIO_0                       {}
-   init SOC.IO.GPIO_1                       {}
-   init SOC.IO.Ethernet_0                   {}
+   init SOC.MMIO.TEST                         {}
+   init SOC.MMIO.CLINT                        {}
+   init SOC.MMIO.ITIM                         {}
+   init SOC.MMIO.PLIC                         {}
+   init SOC.MMIO.GEM0                         {}
+   init SOC.MMIO.I2C_0                        {}
+   init SOC.MMIO.GPIO_0                       {}
+   init SOC.MMIO.GPIO_1                       {}
+   init SOC.MMIO.Ethernet_0                   {}
 
    init SOC.Memory.BRAM_CTRL_0              {}
    init SOC.Memory.DMA_0                    {}

--- a/osv/password.dpl
+++ b/osv/password.dpl
@@ -91,12 +91,12 @@ require:
   init Tools.Link.MemoryMap.UserHeap       {}
   init Tools.Link.MemoryMap.UserStack      {}
 
-  init SOC.IO.UART_0                       {Public}
-  init SOC.IO.GEM0                         {Public}
+  init SOC.MMIO.UART_0                       {Public}
+  init SOC.MMIO.GEM0                         {Public}
   init SOC.Memory.Flash_0                  {}
   init SOC.Memory.Ram_0                    {}
 
-  init SOC.IO.TEST                         {}
+  init SOC.MMIO.TEST                         {}
 
   init Tools.Elf.Section.SHF_ALLOC         {}
   init Tools.Elf.Section.SHF_EXECINSTR     {}

--- a/osv/riscv.dpl
+++ b/osv/riscv.dpl
@@ -752,18 +752,18 @@ policy:
     ^ storeGrp(code == _, mem == [Inaccessible], addr == _, env == _ -> fail "cannot access inaccessible memory")
 
 require:
-    init SOC.IO.DEBUG {Inaccessible}
-    init SOC.IO.PRCI {}
-    init SOC.IO.MTIME {}
-    init SOC.IO.QSPI_0 {}
-    init SOC.IO.OTP {}
-    init SOC.IO.MTIME_CMP {}
-    init SOC.IO.EFLASH {}
-    init SOC.IO.AON {}
-    init SOC.IO.TEST {}
-    init SOC.IO.CLINT {}
-    init SOC.IO.ITIM {}
-    init SOC.IO.PLIC {}
-    init SOC.IO.GPIO_0 {}
-    init SOC.IO.UART_0 {}
-    init SOC.IO.GEM0 {}
+    init SOC.MMIO.DEBUG {Inaccessible}
+    init SOC.MMIO.PRCI {}
+    init SOC.MMIO.MTIME {}
+    init SOC.MMIO.QSPI_0 {}
+    init SOC.MMIO.OTP {}
+    init SOC.MMIO.MTIME_CMP {}
+    init SOC.MMIO.EFLASH {}
+    init SOC.MMIO.AON {}
+    init SOC.MMIO.TEST {}
+    init SOC.MMIO.CLINT {}
+    init SOC.MMIO.ITIM {}
+    init SOC.MMIO.PLIC {}
+    init SOC.MMIO.GPIO_0 {}
+    init SOC.MMIO.UART_0 {}
+    init SOC.MMIO.GEM0 {}

--- a/osv/rwx.dpl
+++ b/osv/rwx.dpl
@@ -62,9 +62,9 @@ require:
     init Tools.Link.MemoryMap.UserHeap       {Rd, Wr}
     init Tools.Link.MemoryMap.UserStack      {Rd, Wr}
 
-    init SOC.IO.MROM                         {Rd, Wr}
-    init SOC.IO.UART_0                       {Rd, Wr}
-    init SOC.IO.UART_1                       {Rd, Wr}
+    init SOC.MMIO.MROM                         {Rd, Wr}
+    init SOC.MMIO.UART_0                       {Rd, Wr}
+    init SOC.MMIO.UART_1                       {Rd, Wr}
     init SOC.Memory.Flash_0                  {Rd}
     init SOC.Memory.Ram_0                    {Rd, Wr}
     init SOC.Memory.Code_1                   {Rd, Wr}
@@ -72,15 +72,16 @@ require:
     init SOC.Memory.Code_3                   {Rd, Wr}
     init SOC.Memory.Code_4                   {Rd, Wr}
 
-    init SOC.IO.TEST                         {Rd, Wr}
-    init SOC.IO.CLINT                        {Rd, Wr}
-    init SOC.IO.ITIM                         {Rd, Wr, Ex}
-    init SOC.IO.PLIC                         {Rd, Wr}
-    init SOC.IO.GEM0                         {Rd, Wr}
-    init SOC.IO.I2C_0                        {Rd, Wr}
-    init SOC.IO.GPIO_0                       {Rd, Wr}
-    init SOC.IO.GPIO_1                       {Rd, Wr}
-    init SOC.IO.Ethernet_0                   {Rd, Wr}
+    init SOC.MMIO.TEST                         {Rd, Wr}
+    init SOC.MMIO.CLINT                        {Rd, Wr}
+    init SOC.MMIO.ITIM                         {Rd, Wr, Ex}
+    init SOC.MMIO.PLIC                         {Rd, Wr}
+    init SOC.MMIO.GEM0                         {Rd, Wr}
+    init SOC.MMIO.I2C_0                        {Rd, Wr}
+    init SOC.MMIO.GPIO_0                       {Rd, Wr}
+    init SOC.MMIO.GPIO_1                       {Rd, Wr}
+    init SOC.MMIO.Ethernet_0                   {Rd, Wr}
+    init SOC.PBUS.MAILBOX                    {Rd, Wr}
 
     init SOC.Memory.BRAM_CTRL_0              {Rd, Wr}
     init SOC.Memory.DMA_0                    {Rd, Wr}

--- a/osv/stack.dpl
+++ b/osv/stack.dpl
@@ -73,16 +73,16 @@ require:
     init llvm.Prologue            {Prologue}
     init llvm.Epilogue            {Epilogue}
 
-    init SOC.IO.UART_0                       {}
+    init SOC.MMIO.UART_0                       {}
     init SOC.Memory.Flash_0                  {}
     init SOC.Memory.Ram_0                    {}
 
-    init SOC.IO.GEM0                         {}
-    init SOC.IO.TEST                         {}
-    init SOC.IO.CLINT                        {}
-    init SOC.IO.ITIM                         {}
-    init SOC.IO.PLIC                         {}
-    init SOC.IO.GEM0                         {}
+    init SOC.MMIO.GEM0                         {}
+    init SOC.MMIO.TEST                         {}
+    init SOC.MMIO.CLINT                        {}
+    init SOC.MMIO.ITIM                         {}
+    init SOC.MMIO.PLIC                         {}
+    init SOC.MMIO.GEM0                         {}
 
     init elf.Section.SHF_ALLOC               {}
     init elf.Section.SHF_EXECINSTR           {}

--- a/osv/taint.dpl
+++ b/osv/taint.dpl
@@ -58,13 +58,13 @@ require:
     init Tools.Link.MemoryMap.UserHeap       {}
     init Tools.Link.MemoryMap.UserStack      {}
 
-    init SOC.IO.UART_0                       {Clean}
+    init SOC.MMIO.UART_0                       {Clean}
     init SOC.Memory.Flash_0                  {}
     init SOC.Memory.Ram_0                    {}
 
-    init SOC.IO.TEST                         {}
-    init SOC.IO.CLINT                        {}
-    init SOC.IO.ITIM                         {}
-    init SOC.IO.PLIC                         {}
+    init SOC.MMIO.TEST                         {}
+    init SOC.MMIO.CLINT                        {}
+    init SOC.MMIO.ITIM                         {}
+    init SOC.MMIO.PLIC                         {}
 
     init poc.var.taint                       {Taint}

--- a/osv/testComplex.dpl
+++ b/osv/testComplex.dpl
@@ -88,11 +88,11 @@ require:
     init Tools.Link.MemoryMap.UserHeap       {}
     init Tools.Link.MemoryMap.UserStack      {}
 
-    init SOC.IO.UART_0                       {AllowIO}
+    init SOC.MMIO.UART_0                       {AllowIO}
     init SOC.Memory.Flash_0                  {AllowRom}
     init SOC.Memory.Ram_0                    {AllowMem}
 
-    init SOC.IO.TEST                         {AllowMem}
+    init SOC.MMIO.TEST                         {AllowMem}
 
     init Tools.Elf.Section.SHF_ALLOC         {AllowMem}
     init Tools.Elf.Section.SHF_EXECINSTR     {AllowCode}

--- a/osv/testContext.dpl
+++ b/osv/testContext.dpl
@@ -29,7 +29,7 @@ require:
     init Tools.Link.MemoryMap.UserHeap       {}
     init Tools.Link.MemoryMap.UserStack      {}
 
-    init SOC.IO.UART_0                       {}
+    init SOC.MMIO.UART_0                       {}
     init SOC.Memory.Flash_0                  {}
     init SOC.Memory.Ram_0                    {}
     init dover.Kernel.MemoryMap.Default       {}
@@ -40,7 +40,7 @@ require:
     init dover.riscv.Mach.RegZero                      {}
     init dover.riscv.User.RegZero                      {}
 
-    init SOC.IO.TEST                         {}
+    init SOC.MMIO.TEST                         {}
 
     init Tools.Elf.Section.SHF_ALLOC         {}
     init Tools.Elf.Section.SHF_EXECINSTR     {}
@@ -49,7 +49,7 @@ require:
     init testContext.mainProcA              {codeProcA}
     init testContext.mainProcB              {codeProcB}
 
-    init SOC.IO.TEST                         {}
-    init SOC.IO.CLINT                        {}
-    init SOC.IO.ITIM                         {}
-    init SOC.IO.PLIC                         {}
+    init SOC.MMIO.TEST                         {}
+    init SOC.MMIO.CLINT                        {}
+    init SOC.MMIO.ITIM                         {}
+    init SOC.MMIO.PLIC                         {}

--- a/osv/testSimple.dpl
+++ b/osv/testSimple.dpl
@@ -74,21 +74,21 @@ require:
     init Tools.Link.MemoryMap.UserHeap       {Nothing}
     init Tools.Link.MemoryMap.UserStack      {Nothing}
 
-    init SOC.IO.UART_0                       {Nothing}
+    init SOC.MMIO.UART_0                       {Nothing}
     init SOC.Memory.Flash_0                  {Nothing}
     init SOC.Memory.Ram_0                    {Nothing}
 
-    init SOC.IO.TEST                         {Nothing}
-    init SOC.IO.CLINT                        {Nothing}
-    init SOC.IO.ITIM                         {Nothing}
-    init SOC.IO.PLIC                         {Nothing}
-    init SOC.IO.GEM0                         {Nothing}
-    init SOC.IO.I2C_0                        {Nothing}
-    init SOC.IO.GPIO_0                       {Nothing}
-    init SOC.IO.GPIO_1                       {Nothing}
-    init SOC.IO.Ethernet_0                   {Nothing}
+    init SOC.MMIO.TEST                         {Nothing}
+    init SOC.MMIO.CLINT                        {Nothing}
+    init SOC.MMIO.ITIM                         {Nothing}
+    init SOC.MMIO.PLIC                         {Nothing}
+    init SOC.MMIO.GEM0                         {Nothing}
+    init SOC.MMIO.I2C_0                        {Nothing}
+    init SOC.MMIO.GPIO_0                       {Nothing}
+    init SOC.MMIO.GPIO_1                       {Nothing}
+    init SOC.MMIO.Ethernet_0                   {Nothing}
 
-    init SOC.IO.TEST                         {Nothing}
+    init SOC.MMIO.TEST                         {Nothing}
 
     init Tools.Elf.Section.SHF_ALLOC         {Nothing}
     init Tools.Elf.Section.SHF_EXECINSTR     {Nothing}

--- a/osv/threeClass.dpl
+++ b/osv/threeClass.dpl
@@ -111,14 +111,14 @@ require:
     init Tools.Link.MemoryMap.UserHeap       {}
     init Tools.Link.MemoryMap.UserStack      {}
 
-    init SOC.IO.UART_0                       {}
+    init SOC.MMIO.UART_0                       {}
     init SOC.Memory.Flash_0                  {}
     init SOC.Memory.Ram_0                    {}
 
-    init SOC.IO.TEST                         {}
-    init SOC.IO.CLINT                        {}
-    init SOC.IO.ITIM                         {}
-    init SOC.IO.PLIC                         {}
+    init SOC.MMIO.TEST                         {}
+    init SOC.MMIO.CLINT                        {}
+    init SOC.MMIO.ITIM                         {}
+    init SOC.MMIO.PLIC                         {}
 
     init Tools.Elf.Section.SHF_ALLOC         {}
     init Tools.Elf.Section.SHF_EXECINSTR     {}

--- a/osv/userType.dpl
+++ b/osv/userType.dpl
@@ -83,11 +83,11 @@ require:
   init Tools.Link.MemoryMap.UserHeap       {}
   init Tools.Link.MemoryMap.UserStack      {}
 
-  init SOC.IO.UART_0                       {}
+  init SOC.MMIO.UART_0                       {}
   init SOC.Memory.Flash_0                  {}
   init SOC.Memory.Ram_0                    {}
 
-  init SOC.IO.TEST                         {}
+  init SOC.MMIO.TEST                         {}
 
   init Tools.Elf.Section.SHF_ALLOC         {}
   init Tools.Elf.Section.SHF_EXECINSTR     {}

--- a/policy_tests/tests/test_status.c
+++ b/policy_tests/tests/test_status.c
@@ -77,25 +77,26 @@ void test_fail(){
 
 // print the test status for a positive test case
 int test_done(){
-  uint32_t cycle_hi, cycle_lo;
-  if(test_status_passing && test_status_positive && !test_status_negative){
-  printf("PASS: test passed.\n");
+  if (test_status_passing && test_status_positive && !test_status_negative) {
+    printf("PASS: test passed.\n");
 
-  isp_get_cycle_count(&cycle_hi, &cycle_lo);
-  printf("End time: %uus\n", isp_get_time_usec());
-  printf("End cycles: 0x%x%08x\n", cycle_hi, cycle_lo);
+    uint32_t cycle_hi, cycle_lo, stall_hi, stall_lo;
+    isp_get_cycle_count(&cycle_hi, &cycle_lo);
+    stall_hi = *(volatile uint32_t*)0x100c4;
+    stall_lo = *(volatile uint32_t*)0x100c0;
+    printf("End time: %uus\n", isp_get_time_usec());
+    printf("End cycles: 0x%x%08x\n", cycle_hi, cycle_lo);
+    printf("End cycles stalled: 0x%x%08x\n", stall_hi, stall_lo);
 
-  printf("MSG: End test.\n");
-  isp_test_device_pass();
+    printf("MSG: End test.\n");
+    isp_test_device_pass();
   return 0;
-  }
-  else if(test_status_positive && test_status_negative) {
+  } else if (test_status_positive && test_status_negative) {
     printf("FAIL: error in test, can't be both positive and negative test.\n");
     printf("MSG: End test.\n");
     isp_test_device_fail();
     return 1;
-  }
-  else {
+  } else {
     printf("FAIL: test failed.\n");
     printf("MSG: End test.\n");
     isp_test_device_fail();


### PR DESCRIPTION
Add support for the AP-facing stall counter and print its value at the end of the test.

Also fix some device names in policy files.