### PR TITLE
Add mailbox to inits for policies used by fpga tests

### DIFF
--- a/osv/cfi.dpl
+++ b/osv/cfi.dpl
@@ -104,6 +104,7 @@ require:
     init SOC.MMIO.CLINT                        {}
     init SOC.MMIO.ITIM                         {}
     init SOC.MMIO.PLIC                         {}
+    init SOC.PBUS.MAILBOX                    {}
 
 	init elf.Section.SHF_ALLOC               {}
 	init elf.Section.SHF_EXECINSTR           {}

--- a/osv/heap.dpl
+++ b/osv/heap.dpl
@@ -146,6 +146,7 @@ require:
     init SOC.MMIO.GPIO_0                       {}
     init SOC.MMIO.GPIO_1                       {}
     init SOC.MMIO.Ethernet_0                   {}
+    init SOC.PBUS.MAILBOX                    {}
 
     init SOC.Memory.BRAM_CTRL_0              {}
     init SOC.Memory.DMA_0                    {}

--- a/osv/stack.dpl
+++ b/osv/stack.dpl
@@ -83,6 +83,7 @@ require:
     init SOC.MMIO.ITIM                         {}
     init SOC.MMIO.PLIC                         {}
     init SOC.MMIO.GEM0                         {}
+    init SOC.PBUS.MAILBOX                    {}
 
     init elf.Section.SHF_ALLOC               {}
     init elf.Section.SHF_EXECINSTR           {}


### PR DESCRIPTION
The heap test was generating a TMT miss after printing success, which was affecting the next run test. This resolves that, and adds the section to other policies that are in the normal FPGA tests