### PR TITLE
Cleanup policies

### DIFF
--- a/entities/osv.contextswitch.entities.yml
+++ b/entities/osv.contextswitch.entities.yml
@@ -1,41 +1,41 @@
 -
-  name: contextswitch.save
+  name: entities.contextswitch.save
   elf_name: freertos_risc_v_trap_handler
   tag_all: true
   kind: symbol
   optional: true
 -
-  name: contextswitch.load
+  name: entities.contextswitch.load
   elf_name: freertos_risc_v_trap_handler
   tag_all: true
   kind: symbol
   optional: true
 -
-  name: contextswitch.save
+  name: entities.contextswitch.save
   elf_name: trap_entry
   tag_all: true
   kind: symbol
   optional: true
 -
-  name: contextswitch.load
+  name: entities.contextswitch.load
   elf_name: restore_user_context
   tag_all: true
   kind: symbol
   optional: true
 -
-  name: contextswitch.save
+  name: entities.contextswitch.save
   elf_name: trap_vector
   tag_all: true
   kind: symbol
   optional: true
 -
-  name: contextswitch.load
+  name: entities.contextswitch.load
   elf_name: fastpath_restore
   tag_all: true
   kind: symbol
   optional: true
 -
-  name: contextswitch.load
+  name: entities.contextswitch.load
   elf_name: restore_regs
   tag_all: true
   kind: symbol

--- a/entities/osv.heap.entities.yml
+++ b/entities/osv.heap.entities.yml
@@ -1,41 +1,41 @@
 -
-    name: dover.Kernel.Code.ApplyTag.ucHeap
+    name: entities.ApplyTag.ucHeap
     elf_name: ucHeap
     kind: symbol
     tag_all: true
     optional: true
 - 
-    name: dover.Kernel.Code.ApplyTag.dover_ptr_zero
+    name: entities.ApplyTag.dover_ptr_zero
     elf_name: dover_ptr_zero
     kind: symbol
     tag_all: true
 -
-    name: dover.Kernel.Code.ApplyTag.pvPortMalloc
+    name: entities.ApplyTag.pvPortMalloc
     elf_name: pvPortMalloc
     kind: symbol
     tag_all: true
 -
-    name: dover.Kernel.Code.ApplyTag.dover_tag
+    name: entities.ApplyTag.dover_tag
     elf_name: dover_tag
     kind: symbol
     tag_all: true
 -
-    name: dover.Kernel.Code.ApplyTag.dover_untag
+    name: entities.ApplyTag.dover_untag
     elf_name: dover_untag
     kind: symbol
     tag_all: true
 -
-    name: dover.Kernel.Code.ApplyTag.dover_remove_tag
+    name: entities.ApplyTag.dover_remove_tag
     elf_name: dover_remove_tag
     kind: symbol
     tag_all: true
 -
-    name: dover.Kernel.Code.ApplyTag.dover_ptr_tag
+    name: entities.ApplyTag.dover_ptr_tag
     elf_name: dover_ptr_tag
     kind: symbol
     tag_all: true
 -
-    name: dover.Kernel.Code.ApplyTag.dover_ptr_untag
+    name: entities.ApplyTag.dover_ptr_untag
     elf_name: dover_ptr_untag
     kind: symbol
     tag_all: true

--- a/entities/osv.stack.entities.yml
+++ b/entities/osv.stack.entities.yml
@@ -1,5 +1,5 @@
 -
-    name: dover.Tools.RTL.longjmp
+    name: entities.longjmp
     elf_name: longjmp
     kind: symbol
     tag_all: true

--- a/osv/cfi.dpl
+++ b/osv/cfi.dpl
@@ -1,8 +1,8 @@
 /*
  * Copyright © 2017-2018 The Charles Stark Draper Laboratory, Inc. and/or Dover Microsystems, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
- * Use and disclosure subject to the following license. 
+ * Use and disclosure subject to the following license.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -37,76 +37,62 @@ import:
 
 metadata:
   Target,
-  None,
   Jumping,
   NoCFI
 
 policy:
-    cfiPol = riscvPol
+    cfiPol =
 
-    // special case: allow return to C from asm interrupt handling
-    ^ mretGrp ( env == _ -> env = {} )
+      // special case: allow return to C from asm interrupt handling
+      mretGrp ( env == _ -> env = {} )
 
-     // Case for not checking cfi (asm code)
-    ^ allGrp    (code == [+NoCFI,-Target], env == _ -> env = env )
-         // cases for landing on a jump (bounce)
-    ^ branchGrp (code == [Target], env == [Jumping] -> env = {Jumping})
-    ^ jumpGrp   (code == [Target], env == [Jumping] -> env = {Jumping}, return = {})
-        // cases for a jump to target
-    ^ branchGrp (code == [-Target], env == [-Jumping], op1 == _, op2 == _ -> env = env[Jumping])
-    ^ jumpRegGrp   (code == [-Target], env == [-Jumping], target == _ -> return = {}, env = env[Jumping])
-    ^ jumpGrp   (code == [-Target], env == [-Jumping] -> return = {}, env = env[Jumping])
-        // Case for landing on a target
-    ^ allGrp    (code == [+Target], env == [+Jumping] -> env = env[-Jumping])
-       // Case for normal execution
-    ^ allGrp    (env == [-Jumping] -> env = env)
+      // Case for not checking cfi (asm code)
+    ^ allGrp    (code == {NoCFI}, env == {} -> env = env )
+
+      // Base case for a jump or branch
+    ^ branchGrp (code == {}, env == {}, op1 == _, op2 == _ -> env = {Jumping})
+    ^ jumpRegGrp(code == {}, env == {}, target == _ -> return = {}, env = {Jumping})
+    ^ jumpGrp   (code == {}, env == {} -> return = {}, env = {Jumping})
+
+      // Cases for when a jump/branch lands on another control flow
+    ^ branchGrp (code == {Target}, env == {Jumping} -> env = {Jumping})
+    ^ jumpGrp   (code == {Target}, env == {Jumping} -> env = {Jumping}, return = {})
+
+      // Case for landing on a target
+    ^ allGrp    (code == {Target}, env == {Jumping} -> env = {})
+
+      // Case for normal execution
+    ^ allGrp    (code == _, env == {} -> env = env)
     ^ allGrp (-> fail "cfi: Illegal control flow detected")
 
-    main = cfiPol
-
 require:
-    init ISA.RISCV.Reg.Env                   {}
-    init ISA.RISCV.Reg.Default               {}
-    init ISA.RISCV.Reg.RZero                 {}
-    init ISA.RISCV.CSR.Default               {}
-    init ISA.RISCV.CSR.MTVec                 {}
+    init ISA.RISCV.Reg.Env                          {}
+    init ISA.RISCV.Reg.Default                      {}
+    init ISA.RISCV.CSR.Default                      {}
 
-    init llvm.CFI_Call-Tgt                   {Target}
-    init llvm.CFI_Branch-Tgt                 {Target}
-    init llvm.CFI_Return-Tgt                 {Target}
-    init llvm.CFI_Call-Instr                 {NoCFI}
-    init llvm.CFI_Branch-Instr               {NoCFI}
-    init llvm.CFI_Return-Instr               {NoCFI}
-    init llvm.NoCFI                          {NoCFI}
-    
-    init dover.Kernel.MemoryMap.Default       {}
-    init dover.riscv.Mach.PC                           {}
-    init dover.riscv.User.PC                           {}
-    init dover.riscv.Mach.Reg                          {}
-    init dover.riscv.User.Reg                          {}
-    init dover.riscv.Mach.RegZero                      {}
-    init dover.riscv.User.RegZero                      {}
-    init dover.Kernel.MemoryMap.UserStack     {}
-    init dover.Kernel.MemoryMap.UserHeap      {}
-    init dover.SOC.IO.UART                             {None}
-    init dover.SOC.IO.Flash                            {}
-    init dover.SOC.CSR.Default                         {}
-    init dover.SOC.CSR.MTVec                           {}
-    init dover.Kernel.Code.ElfSection.SHF_WRITE     {}
-    init dover.Kernel.Code.ElfSection.SHF_ALLOC     {}
-    init dover.Kernel.Code.ElfSection.SHF_EXECINSTR {}
+    // While this policy doesn't make use of llvm.CFI_*-Instr, explicitly
+    // setting them ensures that the llvm.NoCFI tag is consistent.
+    init llvm.CFI_Call-Tgt                          {Target}
+    init llvm.CFI_Branch-Tgt                        {Target}
+    init llvm.CFI_Return-Tgt                        {Target}
+    init llvm.CFI_Call-Instr                        {NoCFI}
+    init llvm.CFI_Branch-Instr                      {NoCFI}
+    init llvm.CFI_Return-Instr                      {NoCFI}
+    init llvm.NoCFI                                 {NoCFI}
 
-    init SOC.MMIO.UART_0                       {}
-    init SOC.MEMORY.FLASH_0                  {}
-    init SOC.MEMORY.RAM_0                    {}
+    init SOC.MMIO.UART_0                            {}
+    init SOC.MEMORY.FLASH_0                         {}
+    init SOC.MEMORY.RAM_0                           {}
 
-    init SOC.MMIO.TEST                         {}
-    init SOC.MMIO.CLINT                        {}
-    init SOC.MMIO.ITIM                         {}
-    init SOC.MMIO.PLIC                         {}
-    init SOC.CBUS.PLIC                         {}
-    init SOC.PBUS.MAILBOX                    {}
+    init SOC.MMIO.MROM                              {}
+    init SOC.MMIO.TEST                              {}
+    init SOC.MMIO.CLINT                             {}
+    init SOC.MMIO.ITIM                              {}
+    init SOC.MMIO.PLIC                              {}
+    init SOC.CBUS.PLIC                              {}
+    init SOC.PBUS.MAILBOX                           {}
 
-	init elf.Section.SHF_ALLOC               {}
-	init elf.Section.SHF_EXECINSTR           {}
-	init elf.Section.SHF_WRITE               {}
+    init elf.Section.SHF_ALLOC                      {}
+    init elf.Section.SHF_EXECINSTR                  {}
+    init elf.Section.SHF_WRITE                      {}
+

--- a/osv/contextswitch.dpl
+++ b/osv/contextswitch.dpl
@@ -1,8 +1,8 @@
 /*
  * Copyright © 2017-2019 The Charles Stark Draper Laboratory, Inc. and/or Dover Microsystems, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
- * Use and disclosure subject to the following license. 
+ * Use and disclosure subject to the following license.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -47,7 +47,7 @@ policy:
         storeMemGrp(code == [+CSSave], env == {}, addr == _, val == _, mem == _ -> env = env, mem = mem[+(Saved val)])
       ^ storeMemGrp(code == [+CSSave], env == _, addr == _, val == _, mem == _ -> env = {}, mem = mem[+(Saved val),+(SavedPC env)])
       ^ loadMemGrp (code == [+CSLoad], env == _, addr == _, mem == [+(Saved regTags),+(SavedPC envTag)] -> env = envTag, res = regTags)
-      ^ loadMemGrp (code == [+CSLoad], env == _, addr == _, mem == [+(Saved regTags)] -> env = env, res = regTags)
+      ^ loadMemGrp (code == [+CSLoad], env == _, addr == _, mem == [+(Saved regTags)] -> env = {}, res = regTags)
 
 group:
     grp loadMemGrp(RS1:addr, MEM:mem -> RD:res)
@@ -58,31 +58,21 @@ group:
         sd
 
 require:
-    init ISA.RISCV.Reg.Env                   {}
-    init ISA.RISCV.Reg.Default               {}
-    init ISA.RISCV.Reg.RZero                 {}
-    init ISA.RISCV.CSR.Default               {}
-    init ISA.RISCV.CSR.MTVec                 {}
+    init ISA.RISCV.Reg.Env                {}
+    init ISA.RISCV.Reg.Default            {}
+    init ISA.RISCV.CSR.Default            {}
 
-    init Tools.Link.MemoryMap.Default        {}
-    init Tools.Link.MemoryMap.UserHeap       {}
-    init Tools.Link.MemoryMap.UserStack      {}
+    init SOC.MMIO.UART_0                  {}
+    init SOC.MEMORY.FLASH_0               {}
+    init SOC.MEMORY.RAM_0                 {}
 
-    init SOC.MMIO.UART_0                       {}
-    init SOC.MEMORY.FLASH_0                  {}
-    init SOC.MEMORY.RAM_0                    {}
+    init SOC.PBUS.MAILBOX                 {}
+    init SOC.MMIO.TEST                    {}
+    init SOC.MMIO.CLINT                   {}
+    init SOC.MMIO.ITIM                    {}
+    init SOC.MMIO.PLIC                    {}
+    init SOC.CBUS.PLIC                    {}
+    init SOC.MMIO.GEM0                    {}
 
-    init SOC.MMIO.TEST                         {}
-    init SOC.MMIO.CLINT                        {}
-    init SOC.MMIO.ITIM                         {}
-    init SOC.MMIO.PLIC                         {}
-    init SOC.CBUS.PLIC                         {}
-    init SOC.MMIO.GEM0                         {}
-
-    init elf.Section.SHF_ALLOC         {}
-    init elf.Section.SHF_EXECINSTR     {}
-    init elf.Section.SHF_WRITE         {}
-
-    init contextswitch.save {CSSave}
-    init contextswitch.load {CSLoad}
-
+    init entities.contextswitch.save      {CSSave}
+    init entities.contextswitch.load      {CSLoad}

--- a/osv/cpi.dpl
+++ b/osv/cpi.dpl
@@ -1,8 +1,8 @@
 /*
  * Copyright © 2017-2018 The Charles Stark Draper Laboratory, Inc. and/or Dover Microsystems, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
- * Use and disclosure subject to the following license. 
+ * Use and disclosure subject to the following license.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -27,11 +27,11 @@
 module osv.cpi:
 
 /* Function pointers written to memory are tagged.  A write of any other value
- * to that location destroys the tag.  Loads of memory preserve the function pointer 
+ * to that location destroys the tag.  Loads of memory preserve the function pointer
  * tag.  Indirect calls must use a register with the function pointer tag, meaning
  * that it came from an intended fptr write and hasn't been overwritten since.
- * This is effectively CPI in HW, and should be a precise, performant version of 
- * control flow protection.  
+ * This is effectively CPI in HW, and should be a precise, performant version of
+ * control flow protection.
  */
 
 import:
@@ -46,12 +46,12 @@ metadata:
 policy:
     cpiPol = riscvPol
        //When to set FPtr -- always allow jumps through registers set by auipc. this is a must for compatability with
-       //handwrite asm.  
+       //handwrite asm.
      ^ pcGrp ( -> dest = {FPtrMem})
-     ^ addiGrp (code == [+FPtrCreate] -> dest = {FPtrMem}) 
+     ^ addiGrp (code == [+FPtrCreate] -> dest = {FPtrMem})
      ^ storeGrp (code == [+FPtrStore], val == [+FPtrMem], mem == _ -> mem = mem[+FPtrMem])
      ^ loadGrp (mem == [+FPtrMem]  -> res = {FPtrMem})
-     
+
        //When to clear FPtr
      ^ storeGrp (code == [-FPtrCreate], mem == _ -> mem = mem[-FPtrMem])
      ^ loadGrp (mem == [-FPtrMem] -> res = {})
@@ -77,7 +77,7 @@ require:
     init llvm.CPI.FPtrCreate                 {FPtrCreate}
     init llvm.CPI.FPtrStore                  {FPtrStore}
     init llvm.CFI_Return-Instr               {Return-Instr}
-    
+
     init Tools.Link.MemoryMap.Default        {}
     init Tools.Link.MemoryMap.UserHeap       {}
     init Tools.Link.MemoryMap.UserStack      {}
@@ -91,7 +91,7 @@ require:
     init SOC.MMIO.ITIM                         {}
     init SOC.MMIO.PLIC                         {}
     init SOC.CBUS.PLIC                         {}
-   
+
     init Tools.Elf.Section.SHF_ALLOC         {}
     init Tools.Elf.Section.SHF_EXECINSTR     {}
     init Tools.Elf.Section.SHF_WRITE         {}

--- a/osv/globalallow.dpl
+++ b/osv/globalallow.dpl
@@ -1,8 +1,8 @@
 /*
  * Copyright Â© 2017-2019 The Charles Stark Draper Laboratory, Inc. and/or Dover Microsystems, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
- * Use and disclosure subject to the following license. 
+ * Use and disclosure subject to the following license.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -38,28 +38,18 @@ policy:
   global globalallowPol = allGrp (code == _, env == _ -> env = env)
 
 require:
-    init ISA.RISCV.Reg.Env                   {}
-    init ISA.RISCV.Reg.Default               {}
-    init ISA.RISCV.Reg.RZero                 {}
-    init ISA.RISCV.CSR.Default               {}
-    init ISA.RISCV.CSR.MTVec                 {}
-    
-    init Tools.Link.MemoryMap.Default        {}
-    init Tools.Link.MemoryMap.UserHeap       {}
-    init Tools.Link.MemoryMap.UserStack      {}
+    init ISA.RISCV.Reg.Env              {}
+    init ISA.RISCV.Reg.Default          {}
+    init ISA.RISCV.CSR.Default          {}
 
-    init SOC.MMIO.UART_0                       {}
-    init SOC.MEMORY.FLASH_0                  {}
-    init SOC.MEMORY.RAM_0                    {}
+    init SOC.MMIO.UART_0                {}
+    init SOC.MEMORY.FLASH_0             {}
+    init SOC.MEMORY.RAM_0               {}
 
-    init SOC.MMIO.TEST                         {}
-    init SOC.MMIO.CLINT                        {}
-    init SOC.MMIO.ITIM                         {}
-    init SOC.MMIO.PLIC                         {}
-    init SOC.CBUS.PLIC                         {}
-    init SOC.MMIO.GEM0                         {}
-
-    init elf.Section.SHF_ALLOC         {}
-    init elf.Section.SHF_EXECINSTR     {}
-    init elf.Section.SHF_WRITE         {}
-
+    init SOC.PBUS.MAILBOX               {}
+    init SOC.MMIO.TEST                  {}
+    init SOC.MMIO.CLINT                 {}
+    init SOC.MMIO.ITIM                  {}
+    init SOC.MMIO.PLIC                  {}
+    init SOC.CBUS.PLIC                  {}
+    init SOC.MMIO.GEM0                  {}

--- a/osv/globalfail.dpl
+++ b/osv/globalfail.dpl
@@ -1,8 +1,8 @@
 /*
  * Copyright Â© 2017-2019 The Charles Stark Draper Laboratory, Inc. and/or Dover Microsystems, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
- * Use and disclosure subject to the following license. 
+ * Use and disclosure subject to the following license.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -38,28 +38,23 @@ policy:
   global globalfailPol = allGrp (code == _, env == _ -> fail "No instructions for you")
 
 require:
-    init ISA.RISCV.Reg.Env                   {}
-    init ISA.RISCV.Reg.Default               {}
-    init ISA.RISCV.Reg.RZero                 {}
-    init ISA.RISCV.CSR.Default               {}
-    init ISA.RISCV.CSR.MTVec                 {}
-    
-    init Tools.Link.MemoryMap.Default        {}
-    init Tools.Link.MemoryMap.UserHeap       {}
-    init Tools.Link.MemoryMap.UserStack      {}
+    init ISA.RISCV.Reg.Env              {}
+    init ISA.RISCV.Reg.Default          {}
+    init ISA.RISCV.CSR.Default          {}
 
-    init SOC.MMIO.UART_0                       {}
-    init SOC.MEMORY.FLASH_0                  {}
-    init SOC.MEMORY.RAM_0                    {}
+    init SOC.MMIO.UART_0                {}
+    init SOC.MEMORY.FLASH_0             {}
+    init SOC.MEMORY.RAM_0               {}
 
-    init SOC.MMIO.TEST                         {}
-    init SOC.MMIO.CLINT                        {}
-    init SOC.MMIO.ITIM                         {}
-    init SOC.MMIO.PLIC                         {}
-    init SOC.CBUS.PLIC                         {}
-    init SOC.MMIO.GEM0                         {}
+    init SOC.PBUS.MAILBOX               {}
+    init SOC.MMIO.TEST                  {}
+    init SOC.MMIO.CLINT                 {}
+    init SOC.MMIO.ITIM                  {}
+    init SOC.MMIO.PLIC                  {}
+    init SOC.CBUS.PLIC                  {}
+    init SOC.MMIO.GEM0                  {}
 
-    init elf.Section.SHF_ALLOC         {}
-    init elf.Section.SHF_EXECINSTR     {}
-    init elf.Section.SHF_WRITE         {}
+    init elf.Section.SHF_ALLOC          {}
+    init elf.Section.SHF_EXECINSTR      {}
+    init elf.Section.SHF_WRITE          {}
 

--- a/osv/heap.dpl
+++ b/osv/heap.dpl
@@ -1,8 +1,8 @@
 /*
  * Copyright © 2017-2018 The Charles Stark Draper Laboratory, Inc. and/or Dover Microsystems, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
- * Use and disclosure subject to the following license. 
+ * Use and disclosure subject to the following license.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -41,126 +41,124 @@ metadata:
   NewColor,          // Special memory cell used with ApplyColor
   DelColor,          // Special memory cell used with RemoveColor
   ModColor,          // Special value used to modify heap cells
-  AntiPointer,       // Special Value that eliminates color from pointers
-  SpecialCaseVFPRINTF  // Mark vprinter code to enable special case hack
-  
-policy:
-  heapPol = riscvPol
-// Handle generic pointer arithmetic
-   ^ arithGrp(env == _, op1 == [-(Pointer _)], op2 == [-(Pointer _)] -> env = env, res = {})
-// since the previous rule didn't fire check for AntiPointer
-   ^ arithGrp(env == _, op1 == [+AntiPointer], op2 == _ -> env = env, res = {})
-   ^ arithGrp(env == _, op1 == _, op2 == [+AntiPointer] -> env = env, res = {})
-// pointer plus scalar retains pointer color   
-   ^ arithGrp(env == _, op1 == [+(Pointer color)], op2 == [-(Pointer _)] -> env = env, res = op1)
-   ^ arithGrp(env == _, op1 == [-(Pointer _)], op2 == [+(Pointer color)] -> env = env, res = op2)
-// Let the compiler mv the tagged data between registers
-   ^ immArithGrp(code == [ApplyColor], env == _, op1 == [ModColor] -> env = env, res = op1)
-   ^ immArithGrp(code == [RemoveColor], env == _, op1 == [ModColor] -> env = env, res = op1)
-// Allow arithmetic on same colored ptrs
-   ^ arithGrp(env == _, op1 == [+(Pointer color)], op2 == [+(Pointer color)] -> env = env, res = op1)
-   ^ arithGrp(env == _, op1 == [+(Pointer _)], op2 == [+(Pointer _)] -> fail "Can not combine different color Pointers")
-   ^ immArithGrp(env == _, op1 == [-(Pointer _)] -> env = env, res = {})
-   ^ immArithGrp(env == _, op1 == [+(Pointer color)] -> env = env, res = op1)
+  KeepPointer        // When doing ptr arithmetic, keep ptr tag on result
 
-// Apply and remove color from heap allocations
-   ^ storeGrp(   code == [ApplyColor], mem == [RawHeap], addr == [+(Pointer color)], val == [ModColor], env == _
+policy:
+  heapPol =
+    // Handle generic non-pointer arithmetic
+    arithGrp(code == _, env == {}, op1 == [-(Pointer _)], op2 == [-(Pointer _)] -> env = env, res = {})
+
+    // TODO: delete once KeepPointer functionality is added
+  ^ arithGrp(code == _, env == {}, op1 == {Pointer color}, op2 == [-(Pointer _)] -> env = env, res = op1)
+  ^ arithGrp(code == _, env == {}, op1 == [-(Pointer _)], op2 == {(Pointer color)} -> env = env, res = op2)
+    // pointer plus scalar retains pointer color iff LLVM static analysis says to
+//   ^ arithGrp(code == {KeepPointer}, env == {}, op1 == {Pointer color}, op2 == {} -> env = env, res = op1)
+//   ^ arithGrp(code == {KeepPointer}, env == {}, op1 == {}, op2 == {(Pointer color)} -> env = env, res = op2)
+//   ^ arithGrp(code == {KeepPointer}, env == {}, op1 == {}, op2 == {} -> env = env, res = {})
+//   ^ arithGrp(code == {}, env == {}, op1 == {Pointer color}, op2 == {} -> env = env, res = {})
+//   ^ arithGrp(code == {}, env == {}, op1 == {}, op2 == {(Pointer color)} -> env = env, res = {})
+    // Let the compiler mv the tagged data between registers
+  ^ immArithGrp(code == {ApplyColor}, env == {}, op1 == {ModColor} -> env = env, res = op1)
+  ^ immArithGrp(code == {RemoveColor}, env == {}, op1 == {ModColor} -> env = env, res = op1)
+    // Allow arithmetic on same colored ptrs
+  ^ arithGrp(code == _, env == {}, op1 == [+(Pointer color)], op2 == [+(Pointer color)] -> env = env, res = op1)
+  ^ arithGrp(code == _, env == {}, op1 == [+(Pointer _)], op2 == [+(Pointer _)] -> fail "Can not combine different color Pointers")
+  ^ immArithGrp(code == _, env == {}, op1 == [-(Pointer _)] -> env = env, res = {})
+  ^ immArithGrp(code == _, env == {}, op1 == [+(Pointer color)] -> env = env, res = op1)
+
+    // Apply and remove color from heap allocations
+  ^ storeGrp(   code == {ApplyColor}, mem == [RawHeap], addr == [+(Pointer color)], val == {ModColor}, env == {}
               -> mem = {(Cell color)}, env = env )
-   ^ storeGrp(   code == [RemoveColor], mem == [+(Cell color)], addr == [+(Pointer color)], val == [ModColor], env == _
+  ^ storeGrp(   code == {RemoveColor}, mem == [+(Cell color)], addr == {(Pointer color)}, val == {ModColor}, env == {}
               -> mem = {RawHeap}, env = env)
-// Allow load and store to heap
-   ^ loadGrp(    mem == [+(Cell color)], addr == [+(Pointer color)], env == _
+    // Allow load and store to heap
+  ^ loadGrp(    code == [-KeepPointer], mem == [+(Cell color)], addr == [+(Pointer color)], env == {}
              -> res = mem[-(Cell _)], env = env )
-   ^ storeGrp(   mem == [+(Cell color)], addr == [+(Pointer color)], val == _, env == _
+  ^ storeGrp(   code == [-KeepPointer], mem == [+(Cell color)], addr == [+(Pointer color)], val == _, env == {}
               -> mem = val[+(Cell color)], env = env )
 
-// Create new colors
-   ^ storeGrp(   code == [ApplyColor], mem == [+NewColor], env == _
+    // Create new colors
+  ^ storeGrp(   code == {ApplyColor}, mem == [+NewColor], env == {}
               -> mem = mem[(Pointer new)], env = env )
-   ^ storeGrp(   code == [RemoveColor], mem == [+DelColor], env == _
+  ^ storeGrp(   code == {RemoveColor}, mem == [+DelColor], env == {}
               -> mem = mem, env = env )
-   ^ loadGrp(   code == [ApplyColor], mem == [+NewColor], env == _
+  ^ loadGrp(   code == {ApplyColor}, mem == [+NewColor], env == {}
              -> res = mem[-NewColor], env = env )
-   ^ loadGrp(   code == [RemoveColor], mem == [+DelColor], env == _
+  ^ loadGrp(   code == {RemoveColor}, mem == [+DelColor], env == {}
              -> res = {}, env = env )
-             
-// Any other write to pallette needs to maintain its tags
-   ^ storeGrp(   code == _, mem == [+NewColor], env == _
+
+    // Any other write to pallette needs to maintain its tags
+  ^ storeGrp(   code == _, mem == [+NewColor], env == {}
               -> mem = mem, env = env )
-   ^ storeGrp(   code == _, mem == [+DelColor], env == _
+  ^ storeGrp(   code == _, mem == [+DelColor], env == {}
               -> mem = mem, env = env )
-   ^ storeGrp(   code == _, mem == [+ModColor], env == _
+  ^ storeGrp(   code == _, mem == [+ModColor], env == {}
               -> mem = mem, env = env )
 
-// Allow malloc to load store raw heap locations
-   ^ loadGrp(   mem == [RawHeap], addr == [-(Pointer _)], env == _
+    // Allow malloc to load store raw heap locations
+  ^ loadGrp(   code == [-KeepPointer], mem == {RawHeap}, addr == [-(Pointer _)], env == {}
              -> res = {}, env = env )
-   ^ storeGrp(   mem == [RawHeap], addr == [-(Pointer _)], val == _, env == _
+  ^ storeGrp(   code == [-KeepPointer], mem == {RawHeap}, addr == [-(Pointer _)], val == _, env == {}
               -> mem = {RawHeap}, env = env )
 
-// Allow load and store to non-heap locations
-   ^ loadGrp(   mem == [-(Cell _)], addr == [-(Pointer _)], env == _
+    // Allow load and store to non-heap locations
+  ^ loadGrp(   code == [-KeepPointer], mem == [-(Cell _)], addr == [-(Pointer _)], env == {}
              -> res = mem, env = env )
-   ^ storeGrp(   mem == [-(Cell _)], addr == [-(Pointer _)], val == _, env == _
+  ^ storeGrp(   code == [-KeepPointer], mem == [-(Cell _)], addr == [-(Pointer _)], val == _, env == {}
               -> mem = val, env = env )
 
-// non-memory operations
-   ^ branchGrp(code == _, env == _, op1 == _, op2 == _ -> env = env )
-   ^ jumpRegGrp(code == _, env == _, target == _ -> env = env , return = {})
-   ^ jumpGrp(code == _, env == _ -> return = {})
-   ^ loadUpperGrp(code == _, env == _ -> env = env, dest = {})
-   ^ immArithGrp(code == _, env == _, op1 == _ -> env = env, res = {})
-   ^ arithGrp(code == _, env == _, op1 == _, op2 == _ -> env = env, res = {})
-   ^ mulDivRemGrp(code == _, env == _, op1 == _, op2 == _ -> env = env, res = {})
-   ^ csrGrp(code == _, env == _, op1 == _, csr == _ -> env = env, csr = {}, res = {})
-   ^ csriGrp(code == _, env == _, csr == _ -> env = env, csr = {}, res = {})
-   ^ floatGrp(code == _, env == _ -> env = env)
-   ^ privGrp(code == _, env == _ -> env = env)
-
+    // non-memory operations are allowed, but must clear any dest registers
+  ^ branchGrp(code == [-KeepPointer], env == {}, op1 == _, op2 == _ -> env = env )
+  ^ jumpRegGrp(code == [-KeepPointer], env == {}, target == _ -> env = env , return = {})
+  ^ jumpGrp(code == [-KeepPointer], env == {} -> return = {})
+  ^ loadUpperGrp(code == [-KeepPointer], env == {} -> env = env, dest = {})
+  ^ immArithGrp(code == [-KeepPointer], env == {}, op1 == _ -> env = env, res = {})
+  ^ arithGrp(code == [-KeepPointer], env == {}, op1 == _, op2 == _ -> env = env, res = {})
+  ^ csrGrp(code == [-KeepPointer], env == {}, op1 == _, csr == _ -> env = env, csr = {}, res = {})
+  ^ csriGrp(code == [-KeepPointer], env == {}, csr == _ -> env = env, csr = {}, res = {})
+  ^ floatGrp(code == [-KeepPointer], env == {} -> env = env)
+  ^ privGrp(code == [-KeepPointer], env == {} -> env = env)
 
 require:
-    init ISA.RISCV.Reg.Env                   {}
-    init ISA.RISCV.Reg.Default               {}
-    init ISA.RISCV.Reg.RZero                 {}
-    init ISA.RISCV.CSR.Default               {}
-    init ISA.RISCV.CSR.MTVec                 {}
+    init ISA.RISCV.Reg.Env                           {}
+    init ISA.RISCV.Reg.Default                       {}
+    init ISA.RISCV.CSR.Default                       {}
 
-    init Tools.Link.MemoryMap.Default        {}
-    init Tools.Link.MemoryMap.UserHeap       {RawHeap}
-    init Tools.Link.MemoryMap.UserStack      {}
+    // TODO: LLVM doesn't do this yet, nor do the tagging tools handle it.
+    // And it could probably use a better name
+    init llvm.PtrArith_ResPointer                    {KeepPointer}
 
-    init elf.Section.SHF_ALLOC         {}
-    init elf.Section.SHF_EXECINSTR     {}
-    init elf.Section.SHF_WRITE         {}
+    init SOC.MMIO.UART_0                             {}
+    init SOC.MEMORY.FLASH_0                          {}
+    init SOC.MEMORY.RAM_0                            {}
 
-    init SOC.MMIO.UART_0                       {}
-    init SOC.MEMORY.FLASH_0                  {}
-    init SOC.MEMORY.RAM_0                    {}
+    init SOC.MMIO.TEST                               {}
+    init SOC.MMIO.MROM                               {}
+    init SOC.MMIO.CLINT                              {}
+    init SOC.MMIO.ITIM                               {}
+    init SOC.MMIO.PLIC                               {}
+    init SOC.CBUS.PLIC                               {}
+    init SOC.MMIO.GEM0                               {}
+    init SOC.MMIO.I2C_0                              {}
+    init SOC.MMIO.GPIO_0                             {}
+    init SOC.MMIO.GPIO_1                             {}
+    init SOC.MMIO.Ethernet_0                         {}
+    init SOC.PBUS.MAILBOX                            {}
 
-    init SOC.MMIO.TEST                         {}
-    init SOC.MMIO.CLINT                        {}
-    init SOC.MMIO.ITIM                         {}
-    init SOC.MMIO.PLIC                         {}
-    init SOC.CBUS.PLIC                         {}
-    init SOC.MMIO.GEM0                         {}
-    init SOC.MMIO.I2C_0                        {}
-    init SOC.MMIO.GPIO_0                       {}
-    init SOC.MMIO.GPIO_1                       {}
-    init SOC.MMIO.Ethernet_0                   {}
-    init SOC.PBUS.MAILBOX                    {}
+    init SOC.Memory.BRAM_CTRL_0                      {}
+    init SOC.Memory.DMA_0                            {}
+    init SOC.Memory.QSPI_1                           {}
 
-    init SOC.Memory.BRAM_CTRL_0              {}
-    init SOC.Memory.DMA_0                    {}
-    init SOC.Memory.QSPI_1                   {}
-    
-    init dover.Kernel.Code.ApplyTag.ucHeap              {RawHeap}
-    init dover.Kernel.Code.ApplyTag.dover_ptr_zero      {ModColor}
+    init entities.ApplyTag.ucHeap                    {RawHeap}
+    init entities.ApplyTag.dover_ptr_zero            {ModColor}
 
-    init dover.Kernel.Code.ApplyTag.pvPortMalloc        {}
-    init dover.Kernel.Code.ApplyTag.dover_tag           {ApplyColor}
-    init dover.Kernel.Code.ApplyTag.dover_untag         {RemoveColor}
-    init dover.Kernel.Code.ApplyTag.dover_remove_tag    {RemoveColor}
-    init dover.Kernel.Code.ApplyTag.dover_ptr_tag       {NewColor}
-    init dover.Kernel.Code.ApplyTag.dover_ptr_untag     {DelColor}
-    init dover.Tools.RTL._vfprintf_r                    {SpecialCaseVFPRINTF}
-    
+    init entities.ApplyTag.pvPortMalloc              {}
+    init entities.ApplyTag.dover_tag                 {ApplyColor}
+    init entities.ApplyTag.dover_untag               {RemoveColor}
+    init entities.ApplyTag.dover_remove_tag          {RemoveColor}
+    init entities.ApplyTag.dover_ptr_tag             {NewColor}
+    init entities.ApplyTag.dover_ptr_untag           {DelColor}
+
+    init elf.Section.SHF_ALLOC               {}
+    init elf.Section.SHF_EXECINSTR           {}
+    init elf.Section.SHF_WRITE               {}

--- a/osv/loader.dpl
+++ b/osv/loader.dpl
@@ -1,8 +1,8 @@
 /*
  * Copyright © 2017-2019 The Charles Stark Draper Laboratory, Inc. and/or Dover Microsystems, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
- * Use and disclosure subject to the following license. 
+ * Use and disclosure subject to the following license.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -111,30 +111,24 @@ group:
 require:
     init ISA.RISCV.Reg.Env                   {}
     init ISA.RISCV.Reg.Default               {}
-    init ISA.RISCV.Reg.RZero                 {}
     init ISA.RISCV.CSR.Default               {}
-    init ISA.RISCV.CSR.MTVec                 {}
 
-    init Tools.Link.MemoryMap.Default        {}
-    init Tools.Link.MemoryMap.UserHeap       {}
-    init Tools.Link.MemoryMap.UserStack      {}
-
-    init SOC.MMIO.MROM                         {}
-    init SOC.MMIO.UART_0                       {}
+    init SOC.MMIO.MROM                       {}
+    init SOC.MMIO.UART_0                     {}
     init SOC.MEMORY.FLASH_0                  {}
     init SOC.MEMORY.RAM_0                    {}
 
-    init SOC.MMIO.DEBUG                        {}
-    init SOC.MMIO.TEST                         {}
-    init SOC.MMIO.CLINT                        {}
-    init SOC.MMIO.ITIM                         {}
-    init SOC.MMIO.GEM0                         {}
-    init SOC.MMIO.AON                          {}
+    init SOC.PBUS.MAILBOX                    {}
+    init SOC.MMIO.TEST                       {}
+    init SOC.MMIO.CLINT                      {}
+    init SOC.MMIO.ITIM                       {}
+    init SOC.MMIO.GEM0                       {}
+    init SOC.MMIO.AON                        {}
 
-    init elf.Section.SHF_ALLOC         {}
-    init elf.Section.SHF_EXECINSTR     {}
-    init elf.Section.SHF_WRITE         {}
+    init elf.Section.SHF_ALLOC               {}
+    init elf.Section.SHF_EXECINSTR           {}
+    init elf.Section.SHF_WRITE               {}
 
-	init loader.load                        {Loader}
+    init loader.load                         {Loader}
 
 

--- a/osv/none.dpl
+++ b/osv/none.dpl
@@ -1,8 +1,8 @@
 /*
  * Copyright © 2017-2018 The Charles Stark Draper Laboratory, Inc. and/or Dover Microsystems, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
- * Use and disclosure subject to the following license. 
+ * Use and disclosure subject to the following license.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -34,38 +34,42 @@ import:
  */
 
 policy:
-    nonePol = riscvPol ^ __NO_CHECKS
+    nonePol = __NO_CHECKS
 
 require:
-   init ISA.RISCV.Reg.Env                   {}
-   init ISA.RISCV.Reg.Default               {}
-   init ISA.RISCV.Reg.RZero                 {}
-   init ISA.RISCV.CSR.Default               {}
-   init ISA.RISCV.CSR.MTVec                 {}
+    init ISA.RISCV.Reg.Env                   {}
+    init ISA.RISCV.Reg.Default               {}
+    init ISA.RISCV.Reg.RZero                 {}
+    init ISA.RISCV.CSR.Default               {}
+    init ISA.RISCV.CSR.MEPC                  {}
+    init ISA.RISCV.CSR.MTVec                 {}
+    init ISA.RISCV.CSR.MTVal                 {}
 
-   init Tools.Link.MemoryMap.Default        {}
-   init Tools.Link.MemoryMap.UserHeap       {}
-   init Tools.Link.MemoryMap.UserStack      {}
+    init Tools.Link.MemoryMap.Default        {}
+    init Tools.Link.MemoryMap.UserHeap       {}
+    init Tools.Link.MemoryMap.UserStack      {}
 
-   init SOC.MMIO.UART_0                       {}
-   init SOC.MEMORY.FLASH_0                  {}
-   init SOC.MEMORY.RAM_0                    {}
+    init SOC.MMIO.UART_0                     {}
+    init SOC.MEMORY.FLASH_0                  {}
+    init SOC.MEMORY.RAM_0                    {}
 
-   init SOC.MMIO.TEST                         {}
-   init SOC.MMIO.CLINT                        {}
-   init SOC.MMIO.ITIM                         {}
-   init SOC.MMIO.PLIC                         {}
-   init SOC.CBUS.PLIC                         {}
-   init SOC.MMIO.GEM0                         {}
-   init SOC.MMIO.I2C_0                        {}
-   init SOC.MMIO.GPIO_0                       {}
-   init SOC.MMIO.GPIO_1                       {}
-   init SOC.MMIO.Ethernet_0                   {}
+    init SOC.PBUS.MAILBOX                    {}
+    init SOC.MMIO.MROM                       {}
+    init SOC.MMIO.TEST                       {}
+    init SOC.MMIO.CLINT                      {}
+    init SOC.MMIO.ITIM                       {}
+    init SOC.MMIO.PLIC                       {}
+    init SOC.CBUS.PLIC                       {}
+    init SOC.MMIO.GEM0                       {}
+    init SOC.MMIO.I2C_0                      {}
+    init SOC.MMIO.GPIO_0                     {}
+    init SOC.MMIO.GPIO_1                     {}
+    init SOC.MMIO.Ethernet_0                 {}
 
-   init SOC.Memory.BRAM_CTRL_0              {}
-   init SOC.Memory.DMA_0                    {}
-   init SOC.Memory.QSPI_1                   {}
+    init SOC.Memory.BRAM_CTRL_0              {}
+    init SOC.Memory.DMA_0                    {}
+    init SOC.Memory.QSPI_1                   {}
 
-   init elf.Section.SHF_ALLOC               {}
-   init elf.Section.SHF_EXECINSTR           {}
-   init elf.Section.SHF_WRITE               {}
+    init elf.Section.SHF_ALLOC               {}
+    init elf.Section.SHF_EXECINSTR           {}
+    init elf.Section.SHF_WRITE               {}

--- a/osv/password.dpl
+++ b/osv/password.dpl
@@ -1,8 +1,8 @@
 /*
  * Copyright © 2017-2018 The Charles Stark Draper Laboratory, Inc. and/or Dover Microsystems, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
- * Use and disclosure subject to the following license. 
+ * Use and disclosure subject to the following license.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -42,7 +42,7 @@ metadata:
 
 policy:
   passwordPol =
-  
+
     // Explicit failure for writing password out
     storeGrp( mem == [+Public], addr == _, val == [+Password], env == _
             -> fail "Password tried to escape server" )
@@ -56,8 +56,6 @@ policy:
     // Propogate password protection
     ^ arithGrp(env == _, op1 == [+Password], op2 == _ -> env = env, res = op1)
     ^ arithGrp(env == _, op1 == _, op2 == [+Password] -> env = env, res = op2)
-    ^ mulDivRemGrp(code == _, env == _, op1 == [+Password], op2 == _ -> env = env, res = op1)
-    ^ mulDivRemGrp(code == _, env == _, op1 == _, op2 == [+Password] -> env = env, res = op2)
     ^ immArithGrp(env == _, op1 == [+Password] -> env = env, res = op1)
     ^ loadGrp(mem == [+Password], addr == _, env == _ -> env = env, res = mem )
     ^ storeGrp(mem == [+Password], addr == _, val == _, env == _ -> env = env, mem = mem ) 
@@ -71,7 +69,6 @@ policy:
     ^ arithGrp(code == _, env == _, op1 == _, op2 == _ -> env = env, res = {})
     ^ loadGrp(code == _, env == _, addr == _, mem == _ -> env = env, res = {})
     ^ storeGrp(code == _, env == _, addr == _, val == _, mem == _ -> env = env, mem = {})
-    ^ mulDivRemGrp(code == _, env == _, op1 == _, op2 == _ -> env = env, res = {})
     ^ csrGrp(code == _, env == _, op1 == _, csr == _ -> env = env, csr = {}, res = {})
     ^ csriGrp(code == _, env == _, csr == _ -> env = env, csr = {}, res = {})
     ^ privGrp(code == _, env == _ -> env = env)
@@ -81,25 +78,16 @@ policy:
 
 
 require:
-  init ISA.RISCV.Reg.Env                   {}
-  init ISA.RISCV.Reg.Default               {}
-  init ISA.RISCV.Reg.RZero                 {}
-  init ISA.RISCV.CSR.Default               {}
-  init ISA.RISCV.CSR.MTVec                 {}
+    init ISA.RISCV.Reg.Env                   {}
+    init ISA.RISCV.Reg.Default               {}
+    init ISA.RISCV.CSR.Default               {}
 
-  init Tools.Link.MemoryMap.Default        {}
-  init Tools.Link.MemoryMap.UserHeap       {}
-  init Tools.Link.MemoryMap.UserStack      {}
+    init SOC.MMIO.UART_0                     {Public}
+    init SOC.MMIO.GEM0                       {Public}
+    init SOC.MEMORY.FLASH_0                  {}
+    init SOC.MEMORY.RAM_0                    {}
 
-  init SOC.MMIO.UART_0                       {Public}
-  init SOC.MMIO.GEM0                         {Public}
-  init SOC.MEMORY.FLASH_0                  {}
-  init SOC.MEMORY.RAM_0                    {}
+    init SOC.PBUS.MAILBOX                    {}
+    init SOC.MMIO.TEST                       {}
 
-  init SOC.MMIO.TEST                         {}
-
-  init Tools.Elf.Section.SHF_ALLOC         {}
-  init Tools.Elf.Section.SHF_EXECINSTR     {}
-  init Tools.Elf.Section.SHF_WRITE         {}
-
-  init webapp.var.pw_byte                  {Password}
+    init webapp.var.pw_byte                  {Password}

--- a/osv/ppac.dpl
+++ b/osv/ppac.dpl
@@ -1,8 +1,8 @@
 /*
  * Copyright © 2017-2018 The Charles Stark Draper Laboratory, Inc. and/or Dover Microsystems, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
- * Use and disclosure subject to the following license. 
+ * Use and disclosure subject to the following license.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -54,7 +54,7 @@ metadata:
 
   // Memory tag for the current type of active user
   ActiveUser,
-  
+
   // Memory tag for the patient data accessible to the active user
   ActivePatient,
 
@@ -74,7 +74,7 @@ policy:
     // Explicit failure for writing to Patient data without Doctor/Admin privileges
     storeGrp(mem == [+(PatientData _)], code == [-SetPatient], env == [-Doctor, -Admin]
              -> fail "Invalid user writing to patient data")
- 
+
     // Patient data read must match active patient color
     // NOTE: the first rule only matches if the two colors are equal
     // Otherwise, the second rule matches and the policy fails
@@ -88,11 +88,11 @@ policy:
                -> mem = {(PatientData color)}, env = env)
     ^ storeGrp(code == [+RemoveColor], mem == [+(PatientData _)], val == [ModColor]
                -> mem = mem[-(PatientData _)], env = env)
-    
+
     // Color the pointer to user's patient data when assigned as patient
     ^ storeGrp(code == [+SetPatient], addr == [+(Pointer _)], val == [+(Pointer color)]
                -> mem = {(PatientPointer color)})
-   	^ loadGrp(mem == [+(PatientPointer color)], addr == _, env == _ -> env = env, res = mem) 
+    ^ loadGrp(mem == [+(PatientPointer color)], addr == _, env == _ -> env = env, res = mem)
 
     // Tag patient memory, relying on User Type policy
 
@@ -102,7 +102,7 @@ policy:
     // Mark memory as Patient
     ^ storeGrp(code == [+Assignment], env == [+SetPatient] -> mem = {Patient}, env = env)
     // Propogate Patient tag
-   	^ loadGrp(mem == [+Patient], addr == _, env == _ -> env = env, res = mem) 
+        ^ loadGrp(mem == [+Patient], addr == _, env == _ -> env = env, res = mem)
 
     // Same for doctor
     ^ allGrp(code == [+SetDoctor,+Return-Instr], env == [+SetDoctor] -> env = env[-SetDoctor])
@@ -126,8 +126,8 @@ policy:
                -> env = env[+(PatientPointer color)])
 
     // Default: keep memory tags on store
-    ^ storeGrp(mem == [+ActiveUser], val == _ -> env = env, mem = mem) 
-    ^ storeGrp(mem == [+ActivePatient], val == _ -> env = env, mem = mem) 
+    ^ storeGrp(mem == [+ActiveUser], val == _ -> env = env, mem = mem)
+    ^ storeGrp(mem == [+ActivePatient], val == _ -> env = env, mem = mem)
     ^ storeGrp(mem == [+PatientData], addr == _, val == _, env == _ -> env = env, mem = mem)
 
     // Clear PC tags when clearing the active user
@@ -142,7 +142,6 @@ policy:
     ^ arithGrp(code == _, env == _, op1 == _, op2 == _ -> env = env, res = {})
     ^ loadGrp(code == _, env == _, addr == _, mem == _ -> env = env, res = {})
     ^ storeGrp(code == _, env == _, addr == _, val == _, mem == _ -> env = env, mem = {})
-    ^ mulDivRemGrp(code == _, env == _, op1 == _, op2 == _ -> env = env, res = {})
     ^ csrGrp(code == _, env == _, op1 == _, csr == _ -> env = env, csr = {}, res = {})
     ^ csriGrp(code == _, env == _, csr == _ -> env = env, csr = {}, res = {})
     ^ privGrp(code == _, env == _ -> env = env)
@@ -154,13 +153,7 @@ policy:
 require:
   init ISA.RISCV.Reg.Env                   {}
   init ISA.RISCV.Reg.Default               {}
-  init ISA.RISCV.Reg.RZero                 {}
   init ISA.RISCV.CSR.Default               {}
-  init ISA.RISCV.CSR.MTVec                 {}
-
-  init Tools.Elf.Section.SHF_ALLOC         {}
-  init Tools.Elf.Section.SHF_EXECINSTR     {}
-  init Tools.Elf.Section.SHF_WRITE         {}
 
   init llvm.CFI_Return-Instr               {Return-Instr}
 

--- a/osv/riscv.dpl
+++ b/osv/riscv.dpl
@@ -1,8 +1,8 @@
 /*
  * Copyright © 2017-2018 The Charles Stark Draper Laboratory, Inc. and/or Dover Microsystems, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
- * Use and disclosure subject to the following license. 
+ * Use and disclosure subject to the following license.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -26,34 +26,6 @@
 
 module osv.riscv:
 
-policy:
-        // a policy that allows anything and contributes no results
-    allPass = branchGrp(code == _, env == _, op1 == _, op2 == _ -> env = env )
-            ^ jumpRegGrp(code == _, env == _, target == _ -> env = env , return = {})
-            ^ jumpGrp(code == _, env == _ -> return = {})
-            ^ loadUpperGrp(code == _, env == _ -> env = env, dest = {})
-            ^ immArithGrp(code == _, env == _, op1 == _ -> env = env, res = {})
-            ^ arithGrp(code == _, env == _, op1 == _, op2 == _ -> env = env, res = {})
-            ^ loadGrp(code == _, env == _, addr == _, mem == _ -> env = env, res = {})
-            ^ storeGrp(code == _, env == _, addr == _, val == _, mem == _ -> env = env, mem = {})
-            ^ mulDivRemGrp(code == _, env == _, op1 == _, op2 == _ -> env = env, res = {})
-            ^ csrGrp(code == _, env == _, op1 == _, csr == _ -> env = env, csr = {}, res = {})
-            ^ csriGrp(code == _, env == _, csr == _ -> env = env, csr = {}, res = {})
-            ^ privGrp(code == _, env == _ -> env = env)
-//            ^ systemGrp(code == _, env == _ -> env = env)
-
-    notMemPass = branchGrp(code == _, env == _, op1 == _, op2 == _ -> env = env )
-            ^ jumpRegGrp(code == _, env == _, target == _ -> env = env , return = {})
-            ^ jumpGrp(code == _, env == _ -> return = {})
-            ^ loadUpperGrp(code == _, env == _ -> env = env, dest = {})
-            ^ immArithGrp(code == _, env == _, op1 == _ -> env = env, res = {})
-            ^ arithGrp(code == _, env == _, op1 == _, op2 == _ -> env = env, res = {})
-            ^ mulDivRemGrp(code == _, env == _, op1 == _, op2 == _ -> env = env, res = {})
-            ^ csrGrp(code == _, env == _, op1 == _, csr == _ -> env = env, csr = {}, res = {})
-            ^ csriGrp(code == _, env == _, csr == _ -> env = env, csr = {}, res = {})
-            ^ privGrp(code == _, env == _ -> env = env)
-//            ^ systemGrp(code == _, env == _ -> env = env)
-
 group:
     grp branchGrp(RS1:op1, RS2:op2 -> )
         beq
@@ -62,15 +34,10 @@ group:
         bge
         bltu
         bgeu
-    grp retGrp(RS1:target -> )
-        jalr    x0, *
     grp jumpRegGrp(RS1:target -> RD:return)
         jalr
     grp jumpGrp( -> RD:return)
         jal
-    grp callGrp( -> RD:return)
-        jal
-        jalr
 
     grp controlFlowGrp( -> )
         beq
@@ -83,33 +50,10 @@ group:
         jalr
         ecall
 
-    grp pcGrp(-> RD:dest)
-        auipc
-
-    grp addiGrp( -> RD:dest)
-        addi
-
     grp loadUpperGrp(-> RD:dest)
         lui
         auipc
-/*
-    moveGrp(RS1:src -> RD:dest)
-        addi    *, *, 0x0
-*/
-    grp moveGrp(RS1:src -> RD:dest)
-        fmv.w.x
-        fmv.d.x
-        fmv.q.x    
-        fmv.x.w
-        fmv.x.d
-        fmv.x.q
 
-    grp xoriGrp(RS1:op1 -> RD:res)
-        xori
-
-    grp andiGrp(RS1:op1 -> RD:res)
-        andi
-        
     grp immArithGrp(RS1:op1 -> RD:res)
         addi
         slli
@@ -125,9 +69,6 @@ group:
         srliw
         sraiw
 
-    grp xorGrp(RS1:op1, RS2:op2 -> RD:res)
-        xor
-
     grp arithGrp(RS1:op1, RS2:op2 -> RD:res)
         add
         sub
@@ -137,7 +78,7 @@ group:
         xor
         srl
         sra
-        or 
+        or
         and
         addw
         subw
@@ -155,37 +96,6 @@ group:
         amoxor.w
         amoor.w
         amoand.w
-
-
-    grp loadGrp(RS1:addr, MEM:mem -> RD:res)
-        lb
-        lh
-        lw
-        ld
-        lbu
-        lhu
-        lwu
-        flw
-        fld
-        flq
-        lr.w
-        
-    grp storeGrp(RS1:addr, RS2:val, MEM:mem -> MEM:mem)
-        sb
-        sh
-        sw
-        sd
-        fsw
-        fsd
-        fsq
-        sc.w
-
-/*        
-    stackMoveGrp(RS2:src -> MEM:res)
-        sw
-        lw
- */
-    grp mulDivRemGrp(RS1:op1, RS2:op2 -> RD:res)
         mul
         mulw
         mulh
@@ -206,11 +116,36 @@ group:
         fmul.q
         fdiv.q
 
+
+
+    grp loadGrp(RS1:addr, MEM:mem -> RD:res)
+        lb
+        lh
+        lw
+        ld
+        lbu
+        lhu
+        lwu
+        flw
+        fld
+        flq
+        lr.w
+
+    grp storeGrp(RS1:addr, RS2:val, MEM:mem -> MEM:mem)
+        sb
+        sh
+        sw
+        sd
+        fsw
+        fsd
+        fsq
+        sc.w
+
     grp csrGrp(RS1:op1, CSR:csr -> CSR:csr, RD:res)
         csrrw
         csrrs
         csrrc
-        
+
     grp csriGrp(CSR:csr -> CSR:csr, RD:res)
         csrrwi
         csrrsi
@@ -329,9 +264,9 @@ group:
         fclass.q
         fmv.w.x
         fmv.d.x
-        fmv.q.x    
+        fmv.q.x
 
-    grp atomicGrp( -> ) 
+    grp atomicGrp( -> )
         lr.w
         sc.w
         amoadd.w
@@ -382,7 +317,7 @@ group:
         xor
         srl
         sra
-        or 
+        or
         and
         addw
         subw
@@ -550,221 +485,3 @@ group:
         amomaxu.w
         amoswap.w
 
-
-    grp notMemGrp( -> )
-    // branchGrp(RS1:op1, RS2:op2 -> )
-        beq
-        bne
-        blt
-        bge
-        bltu
-        bgeu
-    // jumpGrp(RS1:target -> RD:return)
-        jalr
-        jal
-    // loadUpperGrp(-> RD:dest)
-        lui
-        auipc
-    // immArithGrp(RS1:op1 -> RD:res)
-        addi
-        slli
-        slti
-        sltiu
-        xori
-        srli
-        srai
-        ori
-        andi
-        addiw
-        slliw
-        srliw
-        sraiw
-    // arithGrp(RS1:op1, RS2:op2 -> RD:res)
-        add
-        sub
-        sll
-        slt
-        sltu
-        xor
-        srl
-        sra
-        or 
-        and
-        addw
-        subw
-        sllw
-        srlw
-        sraw
-    // stackMoveGrp(RS2:src -> MEM:res)
-        sw
-        lw
-    // mulDivRemGrp(RS1:op1, RS2:op2 -> RD:res)
-        mul
-        mulw
-        mulh
-        mulhsu
-        mulhu
-        div
-        divu
-        divw
-        divuw
-        rem
-        remu
-        remw
-        remuw
-
-    // csrGrp(RS1:op1, CSR:csr -> CSR:csr, RD:res)
-        csrrw
-        csrrs
-        csrrc
-    // csriGrp(IMM:op1, CSR:csr -> CSR:csr, RD:res)
-        csrrwi
-        csrrsi
-        csrrci
-    // privGrp(op1, op2, res)
-        ecall
-        ebreak
-        uret
-        sret
-        mret
-        sfence.vma
-        wfi
-    // systemGrp()
-        fence
-        fence.i
-//floatGrp( -> )
-        flw
-        fld
-        flq
-        fsw
-        fsd
-        fsq
-        fmadd.s
-        fmsub.s
-        fnmsub.s
-        fnmadd.s
-        fmadd.d
-        fmsub.d
-        fnmsub.d
-        fnmadd.d
-        fmadd.q
-        fmsub.q
-        fnmsub.q
-        fnmadd.q
-        fadd.s
-        fsub.s
-        fmul.s
-        fdiv.s
-        fadd.d
-        fsub.d
-        fmul.d
-        fdiv.d
-        fadd.q
-        fsub.q
-        fmul.q
-        fdiv.q
-        fsgnj.s
-        fsgnjn.s
-        fsgnjx.s
-        fmin.s
-        fmax.s
-        fsgnj.d
-        fsgnjn.d
-        fsgnjx.d
-        fmin.d
-        fmax.d
-        fsgnj.q
-        fsgnjn.q
-        fsgnjx.q
-        fmin.q
-        fmax.q
-        fle.s
-        flt.s
-        feq.s
-        fle.d
-        flt.d
-        feq.d
-        fle.q
-        flt.q
-        feq.q
-        fsqrt.s
-        fcvt.s.d
-        fcvt.d.s
-        fsqrt.d
-        fcvt.s.q
-        fcvt.q.s
-        fcvt.d.q
-        fcvt.q.d
-        fsqrt.q
-        fcvt.w.s
-        fcvt.wu.s
-        fcvt.l.s
-        fcvt.lu.s
-        fcvt.w.d
-        fcvt.wu.d
-        fcvt.l.d
-        fcvt.lu.d
-        fcvt.w.q
-        fcvt.wu.q
-        fcvt.l.q
-        fcvt.lu.q
-        fcvt.s.w
-        fcvt.s.wu
-        fcvt.s.l
-        fcvt.s.lu
-        fcvt.d.w
-        fcvt.d.wu
-        fcvt.d.l
-        fcvt.d.lu
-        fcvt.q.w
-        fcvt.q.wu
-        fcvt.q.l
-        fcvt.q.lu
-        fmv.x.w
-        fclass.s
-        fmv.x.d
-        fclass.d
-        fmv.x.q
-        fclass.q
-        fmv.w.x
-        fmv.d.x
-        fmv.q.x    
-//atomicGrp( -> ) 
-        lr.w
-        sc.w
-        amoadd.w
-        amoadd.w.q
-        amoxor.w
-        amoor.w
-        amoand.w
-        amomin.w
-        amomax.w
-        amominu.w
-        amomaxu.w
-        amoswap.w
-
-metadata:
-    Inaccessible
-
-policy:
-  riscvPol =
-    loadGrp(mem == [Inaccessible], addr == _, env == _ -> fail "cannot access inaccessible memory")
-    ^ storeGrp(code == _, mem == [Inaccessible], addr == _, env == _ -> fail "cannot access inaccessible memory")
-
-require:
-    init SOC.MMIO.DEBUG {Inaccessible}
-    init SOC.MMIO.PRCI {}
-    init SOC.MMIO.MTIME {}
-    init SOC.MMIO.QSPI_0 {}
-    init SOC.MMIO.OTP {}
-    init SOC.MMIO.MTIME_CMP {}
-    init SOC.MMIO.EFLASH {}
-    init SOC.MMIO.AON {}
-    init SOC.MMIO.TEST {}
-    init SOC.MMIO.CLINT {}
-    init SOC.MMIO.ITIM {}
-    init SOC.MMIO.PLIC {}
-    init SOC.CBUS.PLIC {}
-    init SOC.MMIO.GPIO_0 {}
-    init SOC.MMIO.UART_0 {}
-    init SOC.MMIO.GEM0 {}

--- a/osv/rwx.dpl
+++ b/osv/rwx.dpl
@@ -1,8 +1,8 @@
 /*
  * Copyright © 2017-2018 The Charles Stark Draper Laboratory, Inc. and/or Dover Microsystems, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
- * Use and disclosure subject to the following license. 
+ * Use and disclosure subject to the following license.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -37,34 +37,28 @@ import:
       osv.riscv
 
 metadata:
-	Rd,
-	Wr,
-	Ex
-
+        Rd,
+        Wr,
+        Ex
 
 policy:
-  rwxPol = riscvPol
-    ^ loadGrp(mem == [-Rd] -> fail "read violation")
+  rwxPol =
+      loadGrp(mem == [-Rd] -> fail "read violation")
     ^ storeGrp(mem == [-Wr] -> fail "write violation")
     ^ allGrp(code == [-Ex] -> fail "execute violation")
-    ^ loadGrp  (code == [+Ex], env == _, mem == [+Rd] -> res = {}, env = env)
-    ^ storeGrp (code == [+Ex], env == _, mem == [+Wr] -> mem = mem, env = env)
-    ^ allGrp(code == [+Ex], env == _ -> env = env)
+
+    ^ loadGrp  (code == [+Ex], env == {}, mem == [+Rd], addr == {} -> res = {}, env = env)
+    ^ storeGrp (code == [+Ex], env == {}, mem == [+Wr] -> mem = mem, env = env)
+    ^ allGrp(code == [+Ex], env == {} -> env = env)
 
 require:
     init ISA.RISCV.Reg.Env                   {}
     init ISA.RISCV.Reg.Default               {}
-    init ISA.RISCV.Reg.RZero                 {}
     init ISA.RISCV.CSR.Default               {Rd}
-    init ISA.RISCV.CSR.MTVec                 {Rd}
-    
-    init Tools.Link.MemoryMap.Default        {}
-    init Tools.Link.MemoryMap.UserHeap       {Rd, Wr}
-    init Tools.Link.MemoryMap.UserStack      {Rd, Wr}
 
-    init SOC.MMIO.MROM                         {Rd, Wr}
-    init SOC.MMIO.UART_0                       {Rd, Wr}
-    init SOC.MMIO.UART_1                       {Rd, Wr}
+    init SOC.MMIO.MROM                       {Rd, Wr}
+    init SOC.MMIO.UART_0                     {Rd, Wr}
+    init SOC.MMIO.UART_1                     {Rd, Wr}
     init SOC.MEMORY.FLASH_0                  {Rd}
     init SOC.MEMORY.RAM_0                    {Rd, Wr}
     init SOC.Memory.Code_1                   {Rd, Wr}
@@ -72,24 +66,23 @@ require:
     init SOC.Memory.Code_3                   {Rd, Wr}
     init SOC.Memory.Code_4                   {Rd, Wr}
 
-    init SOC.MMIO.TEST                         {Rd, Wr}
-    init SOC.MMIO.CLINT                        {Rd, Wr}
-    init SOC.MMIO.ITIM                         {Rd, Wr, Ex}
-    init SOC.MMIO.PLIC                         {Rd, Wr}
-    init SOC.CBUS.PLIC                         {Rd, Wr}
-    init SOC.MMIO.GEM0                         {Rd, Wr}
-    init SOC.MMIO.I2C_0                        {Rd, Wr}
-    init SOC.MMIO.GPIO_0                       {Rd, Wr}
-    init SOC.MMIO.GPIO_1                       {Rd, Wr}
-    init SOC.MMIO.Ethernet_0                   {Rd, Wr}
+    init SOC.MMIO.TEST                       {Rd, Wr}
+    init SOC.MMIO.CLINT                      {Rd, Wr}
+    init SOC.MMIO.ITIM                       {Rd, Wr, Ex}
+    init SOC.MMIO.PLIC                       {Rd, Wr}
+    init SOC.CBUS.PLIC                       {Rd, Wr}
+    init SOC.MMIO.GEM0                       {Rd, Wr}
+    init SOC.MMIO.I2C_0                      {Rd, Wr}
+    init SOC.MMIO.GPIO_0                     {Rd, Wr}
+    init SOC.MMIO.GPIO_1                     {Rd, Wr}
+    init SOC.MMIO.Ethernet_0                 {Rd, Wr}
     init SOC.PBUS.MAILBOX                    {Rd, Wr}
 
     init SOC.Memory.BRAM_CTRL_0              {Rd, Wr}
     init SOC.Memory.DMA_0                    {Rd, Wr}
     init SOC.Memory.QSPI_1                   {Rd}
 
-    init elf.Section.SHF_ALLOC         {Rd}
-    init elf.Section.SHF_EXECINSTR     {Ex}
-    init elf.Section.SHF_WRITE         {Rd, Wr}
-
+    init elf.Section.SHF_ALLOC               {Rd}
+    init elf.Section.SHF_EXECINSTR           {Ex}
+    init elf.Section.SHF_WRITE               {Rd, Wr}
 

--- a/osv/stack.dpl
+++ b/osv/stack.dpl
@@ -1,8 +1,8 @@
 /*
  * Copyright © 2017-2018 The Charles Stark Draper Laboratory, Inc. and/or Dover Microsystems, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
- * Use and disclosure subject to the following license. 
+ * Use and disclosure subject to the following license.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -43,48 +43,48 @@ metadata:
 
 policy:
 
-    stackPol = riscvPol
-                // Prologue and Epilog rules
-             ^ storeGrp (code == [+Prologue], env == _, addr == _, val == _, mem == _ -> mem = {Frame}, env = env)
-             ^ storeGrp (code == [+Epilogue], env == _, addr == _, val == _, mem == _ -> mem = mem[-Frame], env = env)
+    stackPol =
+      // Prologue and Epilog rules
+      storeGrp (code == {Prologue}, env == {}, addr == {}, val == {}, mem == _ -> mem = {Frame}, env = env)
+    ^ storeGrp (code == {Epilogue}, env == {}, addr == {}, val == {}, mem == _ -> mem = {}, env = env)
 
-                // Authority for clearing swaths of stack (e.g. for longjmp)
-             ^ storeGrp (code == [ClearAuthority], env == _, addr == _, val == _, mem == _ -> mem = mem[-Frame], env = env)
-             
-                // Explicit violation for regular code to modify stack frame
-             ^ storeGrp (code == [-Prologue, -Epilogue], env == _, addr == _, val == _, mem == [+Frame] -> fail "Illegal stack access")
-                // Allow regular stores to non-frame memory
-             ^ storeGrp (code == _, env == _, addr == _, val == _, mem == [-Frame] -> mem = mem, env = env)
-                // Strip Frame Tags on load to keep out of registers
-             ^ loadGrp(code == _, env == _, addr == _, mem == _ -> env = env, res = {})
-                // Everything else allowed
-             ^ notMemGrp(code == _, env == _ -> env = env)
+      // Authority for clearing swaths of stack (e.g. for longjmp)
+    ^ storeGrp (code == {ClearAuthority}, env == {}, addr == {}, val == {}, mem == _ -> mem = {}, env = env)
 
-    
+      // Explicit violation for regular code to modify stack frame
+    ^ storeGrp (code == {}, env == {}, addr == {}, val == {}, mem == {Frame} -> fail "Illegal stack access")
+      // Allow regular stores to non-frame memory
+    ^ storeGrp (code == {}, env == {}, addr == {}, val == {}, mem == {} -> mem = mem, env = env)
+      // Strip Frame Tags on load to keep out of registers
+    ^ loadGrp(code == _, env == {}, addr == {}, mem == _ -> env = env, res = {})
+      // Other non-memory instructions allowed
+    ^ loadGrp(code == _, env == _, addr == _, mem == _ -> fail "Illegal load")
+    ^ storeGrp(code == _, env == _, addr == _, mem == _ -> fail "Illegal store")
+    ^ allGrp(code == _, env == {} -> env = env)
+
 require:
 
     init ISA.RISCV.Reg.Env                   {}
     init ISA.RISCV.Reg.Default               {}
-    init ISA.RISCV.Reg.RZero                 {}
     init ISA.RISCV.CSR.Default               {}
-    init ISA.RISCV.CSR.MTVec                 {}
 
-    init dover.Tools.RTL.longjmp             {ClearAuthority}
-    init llvm.Prologue            {Prologue}
-    init llvm.Epilogue            {Epilogue}
+    init entities.longjmp                    {ClearAuthority}
+    init llvm.Prologue                       {Prologue}
+    init llvm.Epilogue                       {Epilogue}
 
-    init SOC.MMIO.UART_0                       {}
+    init SOC.MMIO.UART_0                     {}
     init SOC.MEMORY.FLASH_0                  {}
     init SOC.MEMORY.RAM_0                    {}
 
-    init SOC.MMIO.GEM0                         {}
-    init SOC.MMIO.TEST                         {}
-    init SOC.MMIO.CLINT                        {}
-    init SOC.MMIO.ITIM                         {}
-    init SOC.MMIO.PLIC                         {}
-    init SOC.CBUS.PLIC                         {}
-    init SOC.MMIO.GEM0                         {}
+    init SOC.MMIO.GEM0                       {}
+    init SOC.MMIO.TEST                       {}
+    init SOC.MMIO.CLINT                      {}
+    init SOC.MMIO.ITIM                       {}
+    init SOC.MMIO.PLIC                       {}
+    init SOC.CBUS.PLIC                       {}
+    init SOC.MMIO.GEM0                       {}
     init SOC.PBUS.MAILBOX                    {}
+    init SOC.MMIO.MROM                       {}
 
     init elf.Section.SHF_ALLOC               {}
     init elf.Section.SHF_EXECINSTR           {}

--- a/osv/taint.dpl
+++ b/osv/taint.dpl
@@ -9,63 +9,56 @@ metadata:
   Clean  // can tainted data be written here?
 
 policy:
-  taintPol = riscvPol
+  taintPol =
 
-   // explicit failure for write tainted val to clean addr
-   ^ storeGrp(   mem == [+Clean], addr == _, val == [+Taint], env == _
+      // explicit failure for write tainted val to clean addr
+      storeGrp(   mem == [+Clean], addr == _, val == [+Taint], env == _
                  -> fail "Tainted data written to clean memory")
 
-   // Propogate taint
-   ^ arithGrp(env == _, op1 == [+Taint], op2 == _ -> env = env, res = op1)
-   ^ arithGrp(env == _, op1 == _, op2 == [+Taint] -> env = env, res = op2)
-   ^ mulDivRemGrp(code == _, env == _, op1 == [+Taint], op2 == _ -> env = env, res = op1)
-   ^ mulDivRemGrp(code == _, env == _, op1 == _, op2 == [+Taint] -> env = env, res = op2)
-   ^ immArithGrp(env == _, op1 == [+Taint] -> env = env, res = op1)
-   ^ loadGrp(mem == [+Taint], addr == _, env == _ -> env = env, res = mem )
-   ^ loadGrp(mem == _, addr == [+Taint], env == _ -> env = env, res = addr )
-   ^ storeGrp(mem == _, addr == _, val == [+Taint], env == _ -> env = env, mem = val)
-   ^ storeGrp(mem == [+Taint], addr == _, val == _, env == _ -> env = env, mem = mem ) 
+      // Propogate taint
+    ^ arithGrp(env == _, op1 == [+Taint], op2 == _ -> env = env, res = op1)
+    ^ arithGrp(env == _, op1 == _, op2 == [+Taint] -> env = env, res = op2)
+    ^ immArithGrp(env == _, op1 == [+Taint] -> env = env, res = op1)
+    ^ loadGrp(mem == [+Taint], addr == _, env == _ -> env = env, res = mem )
+    ^ loadGrp(mem == _, addr == [+Taint], env == _ -> env = env, res = addr )
+    ^ storeGrp(mem == _, addr == _, val == [+Taint], env == _ -> env = env, mem = val)
+    ^ storeGrp(mem == [+Taint], addr == _, val == _, env == _ -> env = env, mem = mem )
 
-   // keep clean mem stays clean always
-   ^ storeGrp(   mem == [+Clean], addr == _, val == _, env == _ -> env = env, mem = mem)
+      // keep clean mem stays clean always
+    ^ storeGrp(   mem == [+Clean], addr == _, val == _, env == _ -> env = env, mem = mem)
 
 
-   // default: allow other operations
-   ^ branchGrp(code == _, env == _, op1 == _, op2 == _ -> env = env )
-   ^ jumpRegGrp(code == _, env == _, target == _ -> env = env , return = {})
-   ^ jumpGrp(code == _, env == _ -> return = {})
-   ^ loadUpperGrp(code == _, env == _ -> env = env, dest = {})
-   ^ immArithGrp(code == _, env == _, op1 == _ -> env = env, res = {})
-   ^ arithGrp(code == _, env == _, op1 == _, op2 == _ -> env = env, res = {})
-   ^ loadGrp(code == _, env == _, addr == _, mem == _ -> env = env, res = {})
-   ^ storeGrp(code == _, env == _, addr == _, val == _, mem == _ -> env = env, mem = {})
-   ^ mulDivRemGrp(code == _, env == _, op1 == _, op2 == _ -> env = env, res = {})
-   ^ csrGrp(code == _, env == _, op1 == _, csr == _ -> env = env, csr = {}, res = {})
-   ^ csriGrp(code == _, env == _, csr == _ -> env = env, csr = {}, res = {})
-   ^ privGrp(code == _, env == _ -> env = env)
-   ^ systemGrp(code == _, env == _ -> env = env)
-   ^ floatGrp(code == _, env == _ -> env = env)
-   ^ atomicGrp(code == _, env == _ -> env = env)
+      // default: allow other operations
+    ^ branchGrp(code == _, env == _, op1 == _, op2 == _ -> env = env )
+    ^ jumpRegGrp(code == _, env == _, target == _ -> env = env , return = {})
+    ^ jumpGrp(code == _, env == _ -> return = {})
+    ^ loadUpperGrp(code == _, env == _ -> env = env, dest = {})
+    ^ immArithGrp(code == _, env == _, op1 == _ -> env = env, res = {})
+    ^ arithGrp(code == _, env == _, op1 == _, op2 == _ -> env = env, res = {})
+    ^ loadGrp(code == _, env == _, addr == _, mem == _ -> env = env, res = {})
+    ^ storeGrp(code == _, env == _, addr == _, val == _, mem == _ -> env = env, mem = {})
+    ^ csrGrp(code == _, env == _, op1 == _, csr == _ -> env = env, csr = {}, res = {})
+    ^ csriGrp(code == _, env == _, csr == _ -> env = env, csr = {}, res = {})
+    ^ privGrp(code == _, env == _ -> env = env)
+    ^ systemGrp(code == _, env == _ -> env = env)
+    ^ floatGrp(code == _, env == _ -> env = env)
+    ^ atomicGrp(code == _, env == _ -> env = env)
 
 require:
     init ISA.RISCV.Reg.Env                   {}
     init ISA.RISCV.Reg.Default               {}
-    init ISA.RISCV.Reg.RZero                 {}
     init ISA.RISCV.CSR.Default               {}
-    init ISA.RISCV.CSR.MTVec                 {}
 
-    init Tools.Link.MemoryMap.Default        {}
-    init Tools.Link.MemoryMap.UserHeap       {}
-    init Tools.Link.MemoryMap.UserStack      {}
-
-    init SOC.MMIO.UART_0                       {Clean}
+    init SOC.MMIO.UART_0                     {Clean}
     init SOC.MEMORY.FLASH_0                  {}
     init SOC.MEMORY.RAM_0                    {}
 
-    init SOC.MMIO.TEST                         {}
-    init SOC.MMIO.CLINT                        {}
-    init SOC.MMIO.ITIM                         {}
-    init SOC.MMIO.PLIC                         {}
-    init SOC.CBUS.PLIC                         {}
+    init SOC.PBUS.MAILBOX                    {}
+    init SOC.MMIO.MROM                       {}
+    init SOC.MMIO.TEST                       {}
+    init SOC.MMIO.CLINT                      {}
+    init SOC.MMIO.ITIM                       {}
+    init SOC.MMIO.PLIC                       {}
+    init SOC.CBUS.PLIC                       {}
 
     init poc.var.taint                       {Taint}

--- a/osv/testComplex.dpl
+++ b/osv/testComplex.dpl
@@ -1,8 +1,8 @@
 /*
  * Copyright © 2017-2018 The Charles Stark Draper Laboratory, Inc. and/or Dover Microsystems, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
- * Use and disclosure subject to the following license. 
+ * Use and disclosure subject to the following license.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -27,7 +27,7 @@
 module osv.testComplex:
 
 /*
- * The Complex Test policy provides very little security in a complicated 
+ * The Complex Test policy provides very little security in a complicated
  * way.  It is intended to stress test policy compilation, system tag
  * initialization, and policy execution.
  *
@@ -75,7 +75,7 @@ policy:           // Allow most ops involving regular registers, memory & csrs
    ^ csriGrp(code == [AllowCode], env == [AllowEnv], csr == [AllowCSR] -> csr = {AllowCSR}, res = {AllowReg}, env = {AllowEnv} )
      // Change privledge mode
    ^ privGrp(code == [AllowCode], env == [AllowEnv] -> env = {AllowEnv})
-   
+
 
 require:
     init ISA.RISCV.Reg.Env                   {AllowEnv}

--- a/osv/testContext.dpl
+++ b/osv/testContext.dpl
@@ -10,47 +10,40 @@ metadata:
       codeProcB
 
 policy:
-
-    testContextPol= riscvPol
-            ^ allGrp(code == [+codeProcA], env == [-procB] -> env = env[+procA])
-            ^ allGrp(code == [+codeProcB], env == [-procA] -> env = env[+procB])
-            ^ allGrp(code == [+codeProcA], env == _ -> fail "procB PC tag carried over")
-            ^ allGrp(code == [+codeProcB], env == _ -> fail "procA PC tag carried over")
-            ^ allGrp(code == _, env == _ -> env = env)
+    testContextPol=
+        // Initialize env based on code running
+        allGrp(code == {codeProcA}, env == {} -> env = {procA})
+      ^ allGrp(code == {codeProcB}, env == {} -> env = {procB})
+        // Once initialized, it should always align
+      ^ allGrp(code == {codeProcA}, env == {procA} -> env = {procA})
+      ^ allGrp(code == {codeProcB}, env == {procB} -> env = {procB})
+        // The env tag should never be wrong
+      ^ allGrp(code == {codeProcA}, env == {procB} -> fail "procB PC tag carried over")
+      ^ allGrp(code == {codeProcB}, env == {procA} -> fail "procA PC tag carried over")
+        // In all other code, maintain the env tag
+      ^ allGrp(code == {}, env == _ -> env = env)
 
 require:
-    init ISA.RISCV.Reg.Env                   {}
-    init ISA.RISCV.Reg.Default               {}
-    init ISA.RISCV.Reg.RZero                 {}
-    init ISA.RISCV.CSR.Default               {}
-    init ISA.RISCV.CSR.MTVec                 {}
+    init ISA.RISCV.Reg.Env                    {}
+    init ISA.RISCV.Reg.Default                {}
+    init ISA.RISCV.CSR.Default                {}
 
-    init Tools.Link.MemoryMap.Default        {}
-    init Tools.Link.MemoryMap.UserHeap       {}
-    init Tools.Link.MemoryMap.UserStack      {}
+    init SOC.MMIO.UART_0                      {}
+    init SOC.MEMORY.FLASH_0                   {}
+    init SOC.MEMORY.RAM_0                     {}
 
-    init SOC.MMIO.UART_0                       {}
-    init SOC.MEMORY.FLASH_0                  {}
-    init SOC.MEMORY.RAM_0                    {}
-    init dover.Kernel.MemoryMap.Default       {}
-    init dover.riscv.Mach.PC                           {}
-    init dover.riscv.User.PC                           {}
-    init dover.riscv.Mach.Reg                          {}
-    init dover.riscv.User.Reg                          {}
-    init dover.riscv.Mach.RegZero                      {}
-    init dover.riscv.User.RegZero                      {}
+    init Tools.Elf.Section.SHF_ALLOC          {}
+    init Tools.Elf.Section.SHF_EXECINSTR      {}
+    init Tools.Elf.Section.SHF_WRITE          {}
 
-    init SOC.MMIO.TEST                         {}
+    init testContext.mainProcA                {codeProcA}
+    init testContext.mainProcB                {codeProcB}
 
-    init Tools.Elf.Section.SHF_ALLOC         {}
-    init Tools.Elf.Section.SHF_EXECINSTR     {}
-    init Tools.Elf.Section.SHF_WRITE         {}
 
-    init testContext.mainProcA              {codeProcA}
-    init testContext.mainProcB              {codeProcB}
-
-    init SOC.MMIO.TEST                         {}
-    init SOC.MMIO.CLINT                        {}
-    init SOC.MMIO.ITIM                         {}
-    init SOC.MMIO.PLIC                         {}
-    init SOC.CBUS.PLIC                         {}
+    init SOC.PBUS.MAILBOX                     {}
+    init SOC.MMIO.MROM                        {}
+    init SOC.MMIO.TEST                        {}
+    init SOC.MMIO.CLINT                       {}
+    init SOC.MMIO.ITIM                        {}
+    init SOC.MMIO.PLIC                        {}
+    init SOC.CBUS.PLIC                        {}

--- a/osv/testSimple.dpl
+++ b/osv/testSimple.dpl
@@ -1,8 +1,8 @@
 /*
  * Copyright © 2017-2018 The Charles Stark Draper Laboratory, Inc. and/or Dover Microsystems, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
- * Use and disclosure subject to the following license. 
+ * Use and disclosure subject to the following license.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -46,8 +46,8 @@ metadata:
 
 policy:
         // a policy that allows anything and contributes no results
-    testSimplePol = riscvPol
-            ^ branchGrp(code == _, env == _, op1 == _, op2 == _ -> env = env )
+    testSimplePol =
+              branchGrp(code == _, env == _, op1 == _, op2 == _ -> env = env )
             ^ jumpRegGrp(code == _, env == _, target == _ -> env = env , return = {})
             ^ jumpGrp(code == _, env == _ -> return = {})
             ^ loadUpperGrp(code == _, env == _ -> env = env, dest = {})
@@ -55,7 +55,6 @@ policy:
             ^ arithGrp(code == _, env == _, op1 == _, op2 == _ -> env = env, res = {})
             ^ loadGrp(code == _, env == _, addr == _, mem == _ -> env = env, res = {})
             ^ storeGrp(code == _, env == _, addr == _, val == _, mem == _ -> env = env, mem = {})
-            ^ mulDivRemGrp(code == _, env == _, op1 == _, op2 == _ -> env = env, res = {})
             ^ csrGrp(code == _, env == _, op1 == _, csr == _ -> env = env, csr = {}, res = {})
             ^ csriGrp(code == _, env == _, csr == _ -> env = env, csr = {}, res = {})
             ^ privGrp(code == _, env == _ -> env = env)
@@ -66,31 +65,22 @@ policy:
 require:
     init ISA.RISCV.Reg.Env                   {Nothing}
     init ISA.RISCV.Reg.Default               {Nothing}
-    init ISA.RISCV.Reg.RZero                 {Nothing}
     init ISA.RISCV.CSR.Default               {Nothing}
-    init ISA.RISCV.CSR.MTVec                 {Nothing}
 
-    init Tools.Link.MemoryMap.Default        {Nothing}
-    init Tools.Link.MemoryMap.UserHeap       {Nothing}
-    init Tools.Link.MemoryMap.UserStack      {Nothing}
-
-    init SOC.MMIO.UART_0                       {Nothing}
+    init SOC.MMIO.UART_0                     {Nothing}
     init SOC.MEMORY.FLASH_0                  {Nothing}
     init SOC.MEMORY.RAM_0                    {Nothing}
 
-    init SOC.MMIO.TEST                         {Nothing}
-    init SOC.MMIO.CLINT                        {Nothing}
-    init SOC.MMIO.ITIM                         {Nothing}
-    init SOC.MMIO.PLIC                         {Nothing}
-    init SOC.CBUS.PLIC                         {Nothing}
-    init SOC.MMIO.GEM0                         {Nothing}
-    init SOC.MMIO.I2C_0                        {Nothing}
-    init SOC.MMIO.GPIO_0                       {Nothing}
-    init SOC.MMIO.GPIO_1                       {Nothing}
-    init SOC.MMIO.Ethernet_0                   {Nothing}
+    init SOC.PBUS.MAILBOX                    {Nothing}
+    init SOC.MMIO.MROM                       {Nothing}
+    init SOC.MMIO.TEST                       {Nothing}
+    init SOC.MMIO.CLINT                      {Nothing}
+    init SOC.MMIO.ITIM                       {Nothing}
+    init SOC.MMIO.PLIC                       {Nothing}
+    init SOC.CBUS.PLIC                       {Nothing}
+    init SOC.MMIO.GEM0                       {Nothing}
+    init SOC.MMIO.I2C_0                      {Nothing}
+    init SOC.MMIO.GPIO_0                     {Nothing}
+    init SOC.MMIO.GPIO_1                     {Nothing}
+    init SOC.MMIO.Ethernet_0                 {Nothing}
 
-    init SOC.MMIO.TEST                         {Nothing}
-
-    init Tools.Elf.Section.SHF_ALLOC         {Nothing}
-    init Tools.Elf.Section.SHF_EXECINSTR     {Nothing}
-    init Tools.Elf.Section.SHF_WRITE         {Nothing}

--- a/osv/threeClass.dpl
+++ b/osv/threeClass.dpl
@@ -46,59 +46,56 @@ metadata:
   Return-Instr,
   Branch-Instr,
 
-	//State for the 3 cfi classes
+  //State for the 3 cfi classes
   Jumping-Call,
   Jumping-Return,
   Jumping-Branch,
 
   //get out of jail free
   NoCFI,
-  Jumping-NoCFI,
-  None
+  Jumping-NoCFI
 
 policy:
-    threeClassPol = riscvPol
-         // Case for not checking cfi (asm code)
-    ^ allGrp    (code == [+NoCFI], env == _ -> env = {Jumping-NoCFI})
+    threeClassPol =
+      // Case for not checking cfi (asm code)
+      allGrp    (code == {NoCFI}, env == {} -> env = {Jumping-NoCFI})
+    ^ allGrp    (code == {NoCFI}, env == {Jumping-Return} -> env = {Jumping-NoCFI})
+    ^ allGrp    (code == {NoCFI}, env == {Jumping-Call} -> env = {Jumping-NoCFI})
+    ^ allGrp    (code == {NoCFI}, env == {Jumping-Branch} -> env = {Jumping-NoCFI})
 
-         // cases for landing on a jump (bounce)
-    ^ controlFlowGrp  (code == [Branch-Tgt, Branch-Instr], env == [Jumping-Branch] -> env = {Jumping-Branch})
-    ^ controlFlowGrp  (code == [Return-Tgt, Branch-Instr], env == [Jumping-Return] -> env = {Jumping-Branch})
-    ^ controlFlowGrp  (code == [Call-Tgt, Branch-Instr], env == [Jumping-Call] -> env = {Jumping-Branch})
+      // cases for landing on a jump (bounce)
+    ^ controlFlowGrp  (code == [Branch-Tgt, Branch-Instr, -Call-Instr, -Return-Instr, -NoCFI], env == {Jumping-Branch} -> env = {Jumping-Branch})
+    ^ controlFlowGrp  (code == [Return-Tgt, Branch-Instr, -Call-Instr, -Return-Instr, -NoCFI], env == {Jumping-Return} -> env = {Jumping-Branch})
+    ^ controlFlowGrp  (code == [Call-Tgt, Branch-Instr, -Call-Instr, -Return-Instr, -NoCFI], env == {Jumping-Call} -> env = {Jumping-Branch})
 
-    ^ controlFlowGrp  (code == [Branch-Tgt, Return-Instr], env == [Jumping-Branch] -> env = {Jumping-Return})
-    ^ controlFlowGrp  (code == [Return-Tgt, Return-Instr], env == [Jumping-Return] -> env = {Jumping-Return})
-    ^ controlFlowGrp  (code == [Call-Tgt, Return-Instr], env == [Jumping-Call] -> env = {Jumping-Return})
+    ^ controlFlowGrp  (code == [Branch-Tgt, Return-Instr, -NoCFI], env == {Jumping-Branch} -> env = {Jumping-Return})
+    ^ controlFlowGrp  (code == [Return-Tgt, Return-Instr, -NoCFI], env == {Jumping-Return} -> env = {Jumping-Return})
+    ^ controlFlowGrp  (code == [Call-Tgt, Return-Instr, -NoCFI], env == {Jumping-Call} -> env = {Jumping-Return})
 
-    ^ controlFlowGrp  (code == [Branch-Tgt, Call-Instr], env == [Jumping-Branch] -> env = {Jumping-Call})
-    ^ controlFlowGrp  (code == [Return-Tgt, Call-Instr], env == [Jumping-Return] -> env = {Jumping-Call})
-    ^ controlFlowGrp  (code == [Call-Tgt, Call-Instr], env == [Jumping-Call] -> env = {Jumping-Call})
+    ^ controlFlowGrp  (code == [Branch-Tgt, Call-Instr, -NoCFI], env == {Jumping-Branch} -> env = {Jumping-Call})
+    ^ controlFlowGrp  (code == [Return-Tgt, Call-Instr, -NoCFI], env == {Jumping-Return} -> env = {Jumping-Call})
+    ^ controlFlowGrp  (code == [Call-Tgt, Call-Instr, -NoCFI], env == {Jumping-Call} -> env = {Jumping-Call})
 
-         // cases for a jump to target
-    ^ controlFlowGrp  (code == [Branch-Instr, -Branch-Tgt, -Call-Tgt, -Return-Tgt], env == [-Jumping-Branch] -> env = {Jumping-Branch})
-    ^ controlFlowGrp  (code == [Return-Instr, -Branch-Tgt, -Call-Tgt, -Return-Tgt], env == [-Jumping-Return] -> env = {Jumping-Return})
-    ^ controlFlowGrp  (code == [Call-Instr, -Branch-Tgt, -Call-Tgt, -Return-Tgt], env == [-Jumping-Call] -> env = {Jumping-Call})
+      // cases for a jump to target
+    ^ controlFlowGrp  (code == [Branch-Instr, -Branch-Tgt, -Call-Tgt, -Return-Tgt, -NoCFI], env == {} -> env = {Jumping-Branch})
+    ^ controlFlowGrp  (code == [Return-Instr, -Branch-Tgt, -Call-Tgt, -Return-Tgt, -NoCFI], env == {} -> env = {Jumping-Return})
+    ^ controlFlowGrp  (code == [Call-Instr, -Branch-Tgt, -Call-Tgt, -Return-Tgt, -NoCFI], env == {} -> env = {Jumping-Call})
 
-         // Case for landing on a target -- has to be allGrp
-    ^ allGrp    (code == [Call-Tgt], env == [+Jumping-Call] -> env = env[-Jumping-Call])
-    ^ allGrp    (code == [Call-Tgt], env == [+Jumping-NoCFI] -> env = env[-Jumping-NoCFI])
-    ^ allGrp    (code == [Return-Tgt], env == [+Jumping-Return] -> env = env[-Jumping-Return])
-    ^ allGrp    (code == [Branch-Tgt], env == [+Jumping-Branch] -> env = env[-Jumping-Branch])
+      // Case for landing on a target -- has to be allGrp
+    ^ allGrp    (code == [Call-Tgt, -NoCFI], env == {Jumping-Call} -> env = env[-Jumping-Call])
+    ^ allGrp    (code == [Call-Tgt, -NoCFI], env == {Jumping-NoCFI} -> env = env[-Jumping-NoCFI])
+    ^ allGrp    (code == [Return-Tgt, -NoCFI], env == {Jumping-Return} -> env = env[-Jumping-Return])
+    ^ allGrp    (code == [Branch-Tgt, -NoCFI], env == {Jumping-Branch} -> env = env[-Jumping-Branch])
 
-         // Case for normal execution
-    ^ allGrp    (env == [-Jumping-Branch, -Jumping-Return, -Jumping-Call] -> env = env)
-    ^ allGrp (-> fail "Illegal control flow detected")
-
-    //main = threeClassPol
+      // Case for normal execution
+    ^ allGrp    (code == _, env == [-Jumping-Branch, -Jumping-Return, -Jumping-Call] -> env = env)
+    ^ allGrp    (code == _, env == _ -> fail "Illegal control flow detected")
 
 require:
     init ISA.RISCV.Reg.Env                   {}
     init ISA.RISCV.Reg.Default               {}
-    init ISA.RISCV.Reg.RZero                 {}
     init ISA.RISCV.CSR.Default               {}
-    init ISA.RISCV.CSR.MTVec                 {}
 
-    /* TODO - this needs to be adjusted for my new tags somehow */
     init llvm.CFI_Call-Tgt                   {Call-Tgt}
     init llvm.CFI_Branch-Tgt                 {Branch-Tgt}
     init llvm.CFI_Return-Tgt                 {Return-Tgt}
@@ -107,24 +104,19 @@ require:
     init llvm.CFI_Return-Instr               {Return-Instr}
     init llvm.NoCFI                          {NoCFI}
 
-    init Tools.Link.MemoryMap.Default        {}
-    init Tools.Link.MemoryMap.UserHeap       {}
-    init Tools.Link.MemoryMap.UserStack      {}
-
-    init SOC.MMIO.UART_0                       {}
+    init SOC.MMIO.UART_0                     {}
     init SOC.MEMORY.FLASH_0                  {}
     init SOC.MEMORY.RAM_0                    {}
 
-    init SOC.MMIO.TEST                         {}
-    init SOC.MMIO.CLINT                        {}
-    init SOC.MMIO.ITIM                         {}
-    init SOC.MMIO.PLIC                         {}
-    init SOC.CBUS.PLIC                         {}
+    init SOC.PBUS.MAILBOX                    {}
+    init SOC.MMIO.MROM                       {}
+    init SOC.MMIO.TEST                       {}
+    init SOC.MMIO.CLINT                      {}
+    init SOC.MMIO.ITIM                       {}
+    init SOC.MMIO.PLIC                       {}
+    init SOC.CBUS.PLIC                       {}
 
-    init Tools.Elf.Section.SHF_ALLOC         {}
-    init Tools.Elf.Section.SHF_EXECINSTR     {}
-    init Tools.Elf.Section.SHF_WRITE         {}
+    init elf.Section.SHF_ALLOC               {}
+    init elf.Section.SHF_EXECINSTR           {}
+    init elf.Section.SHF_WRITE               {}
 
-	init elf.Section.SHF_ALLOC               {}
-	init elf.Section.SHF_EXECINSTR           {}
-	init elf.Section.SHF_WRITE               {}

--- a/osv/userType.dpl
+++ b/osv/userType.dpl
@@ -1,8 +1,8 @@
 /*
  * Copyright © 2017-2018 The Charles Stark Draper Laboratory, Inc. and/or Dover Microsystems, Inc.
- * All rights reserved. 
+ * All rights reserved.
  *
- * Use and disclosure subject to the following license. 
+ * Use and disclosure subject to the following license.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
@@ -49,7 +49,7 @@ policy:
     storeGrp(mem == [+Assigned] -> fail "Attempt to re-assign user permissions denied" )
 
     // Mark memory as assigned
-    ^ storeGrp(code == [Assignment], val == [+TypeAssigner], env == _, mem == _ -> mem = mem[Assigned], env = env)
+    ^ storeGrp(code == [+Assignment], val == [+TypeAssigner], env == _, mem == _ -> mem = mem[Assigned], env = env)
 
     // keep typeassigner tag
     ^ storeGrp(mem == [+TypeAssigner], env == _ -> mem = mem, env = env)
@@ -64,7 +64,6 @@ policy:
     ^ arithGrp(code == _, env == _, op1 == _, op2 == _ -> env = env, res = {})
     ^ loadGrp(code == _, env == _, addr == _, mem == _ -> env = env, res = {})
     ^ storeGrp(code == _, env == _, addr == _, val == _, mem == _ -> env = env, mem = {})
-    ^ mulDivRemGrp(code == _, env == _, op1 == _, op2 == _ -> env = env, res = {})
     ^ csrGrp(code == _, env == _, op1 == _, csr == _ -> env = env, csr = {}, res = {})
     ^ csriGrp(code == _, env == _, csr == _ -> env = env, csr = {}, res = {})
     ^ privGrp(code == _, env == _ -> env = env)
@@ -75,23 +74,14 @@ policy:
 require:
   init ISA.RISCV.Reg.Env                   {}
   init ISA.RISCV.Reg.Default               {}
-  init ISA.RISCV.Reg.RZero                 {}
   init ISA.RISCV.CSR.Default               {}
-  init ISA.RISCV.CSR.MTVec                 {}
 
-  init Tools.Link.MemoryMap.Default        {}
-  init Tools.Link.MemoryMap.UserHeap       {}
-  init Tools.Link.MemoryMap.UserStack      {}
-
-  init SOC.MMIO.UART_0                       {}
+  init SOC.MMIO.UART_0                     {}
   init SOC.MEMORY.FLASH_0                  {}
   init SOC.MEMORY.RAM_0                    {}
 
-  init SOC.MMIO.TEST                         {}
-
-  init Tools.Elf.Section.SHF_ALLOC         {}
-  init Tools.Elf.Section.SHF_EXECINSTR     {}
-  init Tools.Elf.Section.SHF_WRITE         {}
+  init SOC.PBUS.MAILBOX                    {}
+  init SOC.MMIO.TEST                       {}
 
   init webapp.userType.assignment          {Assignment}
   init webapp.userType.typeassigner        {TypeAssigner}

--- a/policy_tests/Makefile
+++ b/policy_tests/Makefile
@@ -15,7 +15,8 @@ JOBS   ?= 1
 all: build-dirs run-tests
 
 # Arguments specific to running on an FPGA
-BITSTREAM ?= $(ISP_PREFIX)/vcu118/bitstreams/soc_chisel_pipe_p1.bit
+BITSTREAM32 ?= $(ISP_PREFIX)/vcu118/bitstreams/soc_chisel_pipe_p1.bit
+BITSTREAM64 ?= $(ISP_PREFIX)/vcu118/bitstreams/soc_chisel_pipe_p2.bit
 STOCK_BITSTREAM ?= $(ISP_PREFIX)/vcu118/bitstreams/soc_chisel_p1.bit
 
 # Standard build configurations can be listed here:
@@ -102,7 +103,7 @@ bare-ssith-p1_POLICIES = heap,stack,rwx
 bare-ssith-p1_XDIST = -n $(JOBS) # run in parallel
 bare-ssith-p1_TIMEOUT = 360
 bare-ssith-p1_SOC_CFG = ssith-p1
-bare-ssith-p1_PYTEST_ARGS = --extra=+bitstream=$(BITSTREAM)
+bare-ssith-p1_PYTEST_ARGS = --extra=+bitstream=$(BITSTREAM32)
 bare-ssith-p1: CONFIG=bare-ssith-p1
 bare-ssith-p1: all
 
@@ -117,7 +118,7 @@ frtos-ssith-p1_POLICIES = cfi,heap,rwx,stack,taint,threeClass,none,testSimple,te
 frtos-ssith-p1_XDIST = -n $(JOBS) # run in parallel
 frtos-ssith-p1_TIMEOUT = 360
 frtos-ssith-p1_SOC_CFG = ssith-p1
-frtos-ssith-p1_PYTEST_ARGS = --extra=+bitstream=$(BITSTREAM)
+frtos-ssith-p1_PYTEST_ARGS = --extra=+bitstream=$(BITSTREAM32)
 frtos-ssith-p1: CONFIG=frtos-ssith-p1
 frtos-ssith-p1: all
 
@@ -132,7 +133,7 @@ bare-ssith-p2_POLICIES = heap,rwx
 bare-ssith-p2_XDIST = -n $(JOBS) # run in parallel
 bare-ssith-p2_TIMEOUT = 360
 bare-ssith-p2_SOC_CFG = ssith-p2
-bare-ssith-p2_PYTEST_ARGS = --extra=+bitstream=$(BITSTREAM)
+bare-ssith-p2_PYTEST_ARGS = --extra=+bitstream=$(BITSTREAM64)
 bare-ssith-p2: CONFIG=bare-ssith-p2
 bare-ssith-p2: all
 
@@ -147,7 +148,7 @@ frtos-ssith-p2_POLICIES = cfi,heap,rwx,stack,taint,threeClass,none,testSimple,te
 frtos-ssith-p2_XDIST = -n $(JOBS) # run in parallel
 frtos-ssith-p2_TIMEOUT = 360
 frtos-ssith-p2_SOC_CFG = ssith-p2
-frtos-ssith-p2_PYTEST_ARGS = --extra=+bitstream=$(BITSTREAM)
+frtos-ssith-p2_PYTEST_ARGS = --extra=+bitstream=$(BITSTREAM64)
 frtos-ssith-p2: CONFIG=frtos-ssith-p2
 frtos-ssith-p2: all
 


### PR DESCRIPTION
This takes a significant pass on cleaning up the policies, particularly the policies that are actually run in CI.

* as a convention, names in entities files now start with `entities.`, so that when seen in the policy inits, it's clear where to find the definition
* many places that weren't specific about the expected tag are now more specific when the expected tag is known. 
  * For example, policies that matched `env == _` while never changing the env tag from `{}` now state `env == {}`
  * CSR tags still have to be `_`. See https://github.com/draperlaboratory/hope-pex-kernel/issues/36
* Many inits were not defined anywhere and have been removed
* Unused tags were removed from policies
* The policy tool automatically assumes `env == _, code == _` if not specified in the rule, but I've added it back into the policies for clarity.
* Some whitespace cleanup